### PR TITLE
feat: support per-body-part sensation selection

### DIFF
--- a/Cathier/Services/ClaudeService.swift
+++ b/Cathier/Services/ClaudeService.swift
@@ -158,6 +158,26 @@ enum ClaudeService {
         return decoded.content.first(where: { $0.type == "text" })?.text ?? ""
     }
 
+    /// Parses "bodypart:sensation" encoded strings into grouped entries.
+    private static func parseBodySensations(_ sensations: [String]) -> (perPart: [(part: String, sensations: [String])], global: [String]) {
+        var perPartDict: [(part: String, sensations: [String])] = []
+        var global: [String] = []
+        for s in sensations {
+            let components = s.split(separator: ":", maxSplits: 1).map(String.init)
+            if components.count == 2 {
+                let part = components[0], sensation = components[1]
+                if let idx = perPartDict.firstIndex(where: { $0.part == part }) {
+                    perPartDict[idx].sensations.append(sensation)
+                } else {
+                    perPartDict.append((part: part, sensations: [sensation]))
+                }
+            } else {
+                global.append(s)
+            }
+        }
+        return (perPartDict, global)
+    }
+
     private static func buildPrompt(
         bodyParts: [String],
         sensations: [String],
@@ -167,17 +187,28 @@ enum ClaudeService {
         language: AppLanguage
     ) -> String {
         let lm = LanguageManager.shared
+        let parsed = parseBodySensations(sensations)
 
         switch language {
         case .zh:
             let parts  = bodyParts.isEmpty  ? "未指定" : bodyParts.joined(separator: "、")
-            let senses = sensations.isEmpty ? "未指定" : sensations.joined(separator: "、")
             let emos   = emotions.isEmpty   ? "说不清楚" : emotions.joined(separator: "、")
+
+            var sensesStr = ""
+            if parsed.perPart.isEmpty && parsed.global.isEmpty {
+                sensesStr = "未指定"
+            } else if parsed.perPart.isEmpty {
+                sensesStr = parsed.global.joined(separator: "、")
+            } else {
+                let parts2 = parsed.perPart.map { "\($0.part)：\($0.sensations.joined(separator: "、"))" }
+                sensesStr = parts2.joined(separator: "；")
+                if !parsed.global.isEmpty { sensesStr += "；" + parsed.global.joined(separator: "、") }
+            }
 
             var prompt = """
             【本次身体扫描】
             身体部位：\(parts)
-            身体感受：\(senses)（强度：\(intensity)/10）
+            身体感受：\(sensesStr)（强度：\(intensity)/10）
             情绪：\(emos)
 
             """
@@ -202,17 +233,26 @@ enum ClaudeService {
 
         case .en:
             let parts  = bodyParts.map { lm.display($0) }
-            let senses = sensations.map { lm.display($0) }
             let emos   = emotions.map { lm.display($0) }
 
             let partsStr  = parts.isEmpty  ? "unspecified" : parts.joined(separator: ", ")
-            let sensesStr = senses.isEmpty ? "unspecified" : senses.joined(separator: ", ")
             let emosStr   = emos.isEmpty   ? "unclear" : emos.joined(separator: ", ")
+
+            var enSensesStr = ""
+            if parsed.perPart.isEmpty && parsed.global.isEmpty {
+                enSensesStr = "unspecified"
+            } else if parsed.perPart.isEmpty {
+                enSensesStr = parsed.global.map { lm.display($0) }.joined(separator: ", ")
+            } else {
+                let parts2 = parsed.perPart.map { "\(lm.display($0.part)): \($0.sensations.map { lm.display($0) }.joined(separator: ", "))" }
+                enSensesStr = parts2.joined(separator: "; ")
+                if !parsed.global.isEmpty { enSensesStr += "; " + parsed.global.map { lm.display($0) }.joined(separator: ", ") }
+            }
 
             var prompt = """
             [Current Body Scan]
             Body areas: \(partsStr)
-            Sensations: \(sensesStr) (Intensity: \(intensity)/10)
+            Sensations: \(enSensesStr) (Intensity: \(intensity)/10)
             Emotions: \(emosStr)
 
             """
@@ -237,17 +277,26 @@ enum ClaudeService {
 
         case .ja:
             let parts  = bodyParts.map { lm.display($0) }
-            let senses = sensations.map { lm.display($0) }
             let emos   = emotions.map { lm.display($0) }
 
             let partsStr  = parts.isEmpty  ? "未指定" : parts.joined(separator: "、")
-            let sensesStr = senses.isEmpty ? "未指定" : senses.joined(separator: "、")
             let emosStr   = emos.isEmpty   ? "不明" : emos.joined(separator: "、")
+
+            var jaSensesStr = ""
+            if parsed.perPart.isEmpty && parsed.global.isEmpty {
+                jaSensesStr = "未指定"
+            } else if parsed.perPart.isEmpty {
+                jaSensesStr = parsed.global.map { lm.display($0) }.joined(separator: "、")
+            } else {
+                let parts2 = parsed.perPart.map { "\(lm.display($0.part))：\($0.sensations.map { lm.display($0) }.joined(separator: "、"))" }
+                jaSensesStr = parts2.joined(separator: "；")
+                if !parsed.global.isEmpty { jaSensesStr += "；" + parsed.global.map { lm.display($0) }.joined(separator: "、") }
+            }
 
             var prompt = """
             【今回のボディスキャン】
             身体の部位：\(partsStr)
-            感覚：\(sensesStr)（強度：\(intensity)/10）
+            感覚：\(jaSensesStr)（強度：\(intensity)/10）
             感情：\(emosStr)
 
             """

--- a/Cathier/ViewModels/CheckInViewModel.swift
+++ b/Cathier/ViewModels/CheckInViewModel.swift
@@ -15,8 +15,21 @@ final class CheckInViewModel {
 
     // MARK: - Step 1: Body Scan
     var selectedBodyParts: Set<String> = []
-    var selectedSensations: Set<String> = []
+    /// Maps each selected body part to its chosen sensations.
+    var bodySensations: [String: Set<String>] = [:]
     var intensity: Double = 5
+
+    /// Flat list of unique sensation names selected across all body parts.
+    var allSelectedSensations: [String] {
+        Array(Set(bodySensations.values.flatMap { $0 })).sorted()
+    }
+
+    /// Encodes per-body-part sensations as "bodypart:sensation" strings for storage.
+    var encodedSensations: [String] {
+        bodySensations.keys.sorted().flatMap { part in
+            (bodySensations[part] ?? []).sorted().map { "\(part):\($0)" }
+        }
+    }
 
     // MARK: - Step 2: Emotion Label
     var selectedCategory: String? = nil
@@ -38,7 +51,7 @@ final class CheckInViewModel {
     }
 
     var canProceedFromBodyScan: Bool {
-        !selectedBodyParts.isEmpty || !selectedSensations.isEmpty
+        !selectedBodyParts.isEmpty
     }
 
     var canProceedFromEmotionLabel: Bool {
@@ -52,7 +65,7 @@ final class CheckInViewModel {
         do {
             aiFeedback = try await ClaudeService.generateFeedback(
                 bodyParts: Array(selectedBodyParts),
-                sensations: Array(selectedSensations),
+                sensations: encodedSensations,
                 intensity: Int(intensity),
                 emotions: allEmotions,
                 recentHistory: recentHistory,
@@ -69,7 +82,7 @@ final class CheckInViewModel {
         let checkIn = CheckIn(
             date: Date(),
             bodyParts: Array(selectedBodyParts),
-            sensations: Array(selectedSensations),
+            sensations: encodedSensations,
             intensity: Int(intensity),
             emotions: allEmotions,
             note: note,
@@ -83,7 +96,7 @@ final class CheckInViewModel {
     func reset() {
         currentStep = .bodyScan
         selectedBodyParts = []
-        selectedSensations = []
+        bodySensations = [:]
         intensity = 5
         selectedCategory = nil
         selectedEmotions = []

--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -177,9 +177,9 @@ struct AIFeedbackView: View {
                          items: viewModel.selectedBodyParts.map { lm.display($0) })
             }
 
-            if !viewModel.selectedSensations.isEmpty {
+            if !viewModel.allSelectedSensations.isEmpty {
                 labelRow(icon: "waveform",
-                         items: viewModel.selectedSensations.map { lm.display($0) })
+                         items: viewModel.allSelectedSensations.map { lm.display($0) })
             }
 
             if !viewModel.allEmotions.isEmpty {

--- a/Cathier/Views/CheckIn/BodyScanView.swift
+++ b/Cathier/Views/CheckIn/BodyScanView.swift
@@ -22,17 +22,27 @@ struct BodyScanView: View {
                     }
                 }
 
-                Divider()
+                // Per-body-part sensations (shown only when body parts are selected)
+                if !viewModel.selectedBodyParts.isEmpty {
+                    Divider()
 
-                // Sensations
-                sectionHeader(title: lm.bodyScanWhatTitle, subtitle: lm.bodyScanMultiple)
-                FlowLayout(spacing: 10) {
-                    ForEach(config.sensations, id: \.self) { sensation in
-                        ChipView(
-                            label: lm.display(sensation),
-                            isSelected: viewModel.selectedSensations.contains(sensation)
-                        ) {
-                            toggleSensation(sensation)
+                    sectionHeader(title: lm.bodyScanWhatTitle, subtitle: lm.bodyScanMultiple)
+                    ForEach(config.bodyParts.filter { viewModel.selectedBodyParts.contains($0) }, id: \.self) { part in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(lm.display(part))
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .foregroundColor(.secondary)
+                            FlowLayout(spacing: 10) {
+                                ForEach(config.sensations, id: \.self) { sensation in
+                                    ChipView(
+                                        label: lm.display(sensation),
+                                        isSelected: viewModel.bodySensations[part]?.contains(sensation) ?? false
+                                    ) {
+                                        toggleSensation(sensation, for: part)
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -82,16 +92,23 @@ struct BodyScanView: View {
     private func toggleBodyPart(_ part: String) {
         if viewModel.selectedBodyParts.contains(part) {
             viewModel.selectedBodyParts.remove(part)
+            viewModel.bodySensations.removeValue(forKey: part)
         } else {
             viewModel.selectedBodyParts.insert(part)
         }
     }
 
-    private func toggleSensation(_ sensation: String) {
-        if viewModel.selectedSensations.contains(sensation) {
-            viewModel.selectedSensations.remove(sensation)
+    private func toggleSensation(_ sensation: String, for part: String) {
+        if viewModel.bodySensations[part]?.contains(sensation) == true {
+            viewModel.bodySensations[part]?.remove(sensation)
+            if viewModel.bodySensations[part]?.isEmpty == true {
+                viewModel.bodySensations.removeValue(forKey: part)
+            }
         } else {
-            viewModel.selectedSensations.insert(sensation)
+            if viewModel.bodySensations[part] == nil {
+                viewModel.bodySensations[part] = []
+            }
+            viewModel.bodySensations[part]?.insert(sensation)
         }
     }
 }

--- a/Cathier/Views/Components/CheckInDetailView.swift
+++ b/Cathier/Views/Components/CheckInDetailView.swift
@@ -31,17 +31,43 @@ struct CheckInDetailView: View {
                                 .font(.subheadline)
                                 .fontWeight(.semibold)
                                 .foregroundColor(.secondary)
-                            if !checkIn.bodyParts.isEmpty {
-                                FlowLayout(spacing: 8) {
-                                    ForEach(checkIn.bodyParts, id: \.self) { part in
-                                        chip(lm.display(part), color: .blue)
+                            let parsed = parsedSensations(checkIn.sensations)
+                            if parsed.perPart.isEmpty {
+                                // Legacy: flat sensation list with body parts shown separately
+                                if !checkIn.bodyParts.isEmpty {
+                                    FlowLayout(spacing: 8) {
+                                        ForEach(checkIn.bodyParts, id: \.self) { part in
+                                            chip(lm.display(part), color: .blue)
+                                        }
                                     }
                                 }
-                            }
-                            if !checkIn.sensations.isEmpty {
-                                FlowLayout(spacing: 8) {
-                                    ForEach(checkIn.sensations, id: \.self) { s in
-                                        chip(lm.display(s), color: .teal)
+                                if !parsed.global.isEmpty {
+                                    FlowLayout(spacing: 8) {
+                                        ForEach(parsed.global, id: \.self) { s in
+                                            chip(lm.display(s), color: .teal)
+                                        }
+                                    }
+                                }
+                            } else {
+                                // New format: per-body-part sensations
+                                ForEach(parsed.perPart, id: \.part) { entry in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(lm.display(entry.part))
+                                            .font(.caption)
+                                            .fontWeight(.medium)
+                                            .foregroundColor(.blue)
+                                        FlowLayout(spacing: 6) {
+                                            ForEach(entry.sensations, id: \.self) { s in
+                                                chip(lm.display(s), color: .teal)
+                                            }
+                                        }
+                                    }
+                                }
+                                if !parsed.global.isEmpty {
+                                    FlowLayout(spacing: 8) {
+                                        ForEach(parsed.global, id: \.self) { s in
+                                            chip(lm.display(s), color: .teal)
+                                        }
                                     }
                                 }
                             }
@@ -111,6 +137,30 @@ struct CheckInDetailView: View {
     }
 
     // MARK: - Helpers
+
+    struct ParsedSensations {
+        var perPart: [(part: String, sensations: [String])]
+        var global: [String]
+    }
+
+    private func parsedSensations(_ sensations: [String]) -> ParsedSensations {
+        var perPartDict: [(part: String, sensations: [String])] = []
+        var global: [String] = []
+        for s in sensations {
+            let components = s.split(separator: ":", maxSplits: 1).map(String.init)
+            if components.count == 2 {
+                let part = components[0], sensation = components[1]
+                if let idx = perPartDict.firstIndex(where: { $0.part == part }) {
+                    perPartDict[idx].sensations.append(sensation)
+                } else {
+                    perPartDict.append((part: part, sensations: [sensation]))
+                }
+            } else {
+                global.append(s)
+            }
+        }
+        return ParsedSensations(perPart: perPartDict, global: global)
+    }
 
     @ViewBuilder
     private func sectionCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {


### PR DESCRIPTION
Closes #6

Encode per-body-part sensations as "bodypart:sensation" strings in the existing `sensations: [String]` field — no schema change required.

Generated with [Claude Code](https://claude.ai/code)