### PR TITLE
feat: add option to share AI feedback with friends

### DIFF
--- a/Cathier/Localization/LanguageManager.swift
+++ b/Cathier/Localization/LanguageManager.swift
@@ -240,6 +240,8 @@ extension LanguageManager {
     var tierEmotionsDesc: String    { s("好友看到具体情绪词", "Friend sees specific emotion words", "友達には具体的な感情の言葉が表示") }
     var tierFullName: String        { s("完整分享",         "Full share",               "完全シェア") }
     var tierFullDesc: String        { s("好友看到全部内容含笔记", "Friend sees everything including notes", "友達にはメモを含む全内容が表示") }
+    var aiShareAIFeedbackToggle: String { s("也分享 AI 反馈", "Also share AI feedback", "AIフィードバックもシェア") }
+    var aiShareAIFeedbackDesc: String   { s("好友也能看到 AI 给你的回应", "Friends can also see the AI's response to you", "友達もAIからのフィードバックを見られます") }
 
     // MARK: FriendFeedView
     var friendNavTitle: String       { s("好友",            "Friends",                  "友達") }

--- a/Cathier/Models/FriendCheckIn.swift
+++ b/Cathier/Models/FriendCheckIn.swift
@@ -42,7 +42,7 @@ struct FriendCheckIn: Identifiable {
     }
 
     /// Build from a local CheckIn before uploading.
-    init(ownerRef: CKRecord.Reference, checkIn: CheckIn, privacyTier: PrivacyTier) {
+    init(ownerRef: CKRecord.Reference, checkIn: CheckIn, privacyTier: PrivacyTier, shareAIFeedback: Bool = false) {
         self.id = CKRecord.ID(recordName: checkIn.id.uuidString)
         self.ownerRef = ownerRef
         self.localID = checkIn.id.uuidString
@@ -52,7 +52,7 @@ struct FriendCheckIn: Identifiable {
         self.sensations = checkIn.sensations
         self.intensity = checkIn.intensity
         self.note = privacyTier == .full ? checkIn.note : ""
-        self.aiFeedback = privacyTier == .full ? checkIn.aiFeedback : ""
+        self.aiFeedback = (privacyTier == .full || shareAIFeedback) ? checkIn.aiFeedback : ""
         self.privacyTier = privacyTier
     }
 

--- a/Cathier/ViewModels/FriendViewModel.swift
+++ b/Cathier/ViewModels/FriendViewModel.swift
@@ -129,9 +129,9 @@ final class FriendViewModel {
 
     // MARK: - Shared check-ins (Phase 2)
 
-    func shareCheckIn(_ checkIn: CheckIn, tier: FriendCheckIn.PrivacyTier) async throws {
+    func shareCheckIn(_ checkIn: CheckIn, tier: FriendCheckIn.PrivacyTier, shareAIFeedback: Bool = false) async throws {
         guard let profile = currentProfile else { return }
-        let shared = FriendCheckIn(ownerRef: profile.reference, checkIn: checkIn, privacyTier: tier)
+        let shared = FriendCheckIn(ownerRef: profile.reference, checkIn: checkIn, privacyTier: tier, shareAIFeedback: shareAIFeedback)
         try await ck.saveSharedCheckIn(shared)
         checkIn.shareLevel = tier.rawValue
     }

--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -9,6 +9,7 @@ struct AIFeedbackView: View {
     let onDismiss: () -> Void
 
     @State private var selectedTier: FriendCheckIn.PrivacyTier? = nil
+    @State private var shareAIFeedback: Bool = false
 
     private var hasFriends: Bool { friendVM.currentProfile != nil && !friendVM.friends.isEmpty }
 
@@ -84,6 +85,12 @@ struct AIFeedbackView: View {
                         Divider()
                     }
                 }
+
+                // AI feedback toggle (shown when sharing at non-full tier with AI feedback available)
+                if let tier = selectedTier, tier != .full, !viewModel.aiFeedback.isEmpty {
+                    Divider()
+                    aiFeedbackToggleRow
+                }
             }
             .padding(12)
             .background(Color(.secondarySystemBackground))
@@ -140,6 +147,25 @@ struct AIFeedbackView: View {
         }
     }
 
+    private var aiFeedbackToggleRow: some View {
+        Toggle(isOn: $shareAIFeedback) {
+            HStack(spacing: 12) {
+                Image(systemName: "sparkles")
+                    .foregroundColor(.orange)
+                    .frame(width: 16)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(lm.aiShareAIFeedbackToggle)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                    Text(lm.aiShareAIFeedbackDesc)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .tint(.orange)
+    }
+
     // MARK: - History
 
     private func fetchRecentHistory() -> [CheckIn] {
@@ -155,7 +181,8 @@ struct AIFeedbackView: View {
     private func saveAction() {
         let checkIn = viewModel.save(context: modelContext)
         if let tier = selectedTier {
-            Task { try? await friendVM.shareCheckIn(checkIn, tier: tier) }
+            let includeAI = tier == .full ? false : shareAIFeedback
+            Task { try? await friendVM.shareCheckIn(checkIn, tier: tier, shareAIFeedback: includeAI) }
         }
         onDismiss()
     }

--- a/Cathier/Views/Friend/FriendFeedView.swift
+++ b/Cathier/Views/Friend/FriendFeedView.swift
@@ -274,6 +274,38 @@ struct FriendCheckInCard: View {
                         .cornerRadius(8)
                 }
             }
+
+            // AI feedback (shown whenever available)
+            if !item.aiFeedback.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "sparkles")
+                            .font(.caption2)
+                            .foregroundColor(.orange)
+                        Text(lm.aiCompanion)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundColor(.orange)
+                    }
+                    Text(item.aiFeedback)
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                        .lineSpacing(3)
+                }
+                .padding(10)
+                .background(
+                    LinearGradient(
+                        colors: [Color.orange.opacity(0.08), Color.orange.opacity(0.03)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.orange.opacity(0.2), lineWidth: 1)
+                )
+                .cornerRadius(8)
+            }
         }
     }
 }


### PR DESCRIPTION
- Add shareAIFeedback toggle in AIFeedbackView share section (visible when a non-full tier is selected and AI feedback exists)
- Pass shareAIFeedback flag through FriendViewModel.shareCheckIn
- Update FriendCheckIn init to include aiFeedback for any tier when shareAIFeedback is true (not just the full tier)
- Display AI feedback card in FriendCheckInCard when available, regardless of privacy tier

Closes #13