### PR TITLE
feat: add daily mood & gains journal module

### DIFF
--- a/Cathier/CathierApp.swift
+++ b/Cathier/CathierApp.swift
@@ -5,7 +5,7 @@ import SwiftData
 struct CathierApp: App {
     let container: ModelContainer = {
         let config = ModelConfiguration(cloudKitDatabase: .private("iCloud.com.wangjianshuo.Cathier"))
-        return try! ModelContainer(for: CheckIn.self, configurations: config)
+        return try! ModelContainer(for: CheckIn.self, DailyJournal.self, configurations: config)
     }()
 
     var body: some Scene {

--- a/Cathier/ContentView.swift
+++ b/Cathier/ContentView.swift
@@ -27,6 +27,6 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
-        .modelContainer(for: CheckIn.self, inMemory: true)
+        .modelContainer(for: [CheckIn.self, DailyJournal.self], inMemory: true)
         .environment(LanguageManager.shared)
 }

--- a/Cathier/Localization/LanguageManager.swift
+++ b/Cathier/Localization/LanguageManager.swift
@@ -327,6 +327,26 @@ extension LanguageManager {
     var settingsLocalOnly: String        { s("iCloud 同步", "iCloud sync",          "iCloud同期") }
     var settingsLanguageSection: String  { s("语言",        "Language",             "言語") }
 
+    // MARK: DailyJournalEntryView
+    var journalEntryNavTitle: String        { s("今日心情与收获",   "Today's Journal",              "今日の気持ちと収穫") }
+    var journalEntryMoodLabel: String       { s("今天心情怎么样？",  "How are you feeling today?",   "今日の気分は？") }
+    var journalEntryGainsLabel: String      { s("今日收获",        "Today's Gains",                "今日の収穫") }
+    var journalEntryGainsPlaceholder: String { s("记录今天的收获、感悟或想说的话…",
+                                                  "Record today's gains, insights, or thoughts…",
+                                                  "今日の収穫、気づき、伝えたいことを記録しよう…") }
+    var journalEntryShareLabel: String      { s("分享给好友",       "Share with Friends",           "友達とシェア") }
+    var journalEntryShareDesc: String       { s("好友可以看到你的心情和收获", "Friends can see your mood and gains", "友達があなたの気分と収穫を見られます") }
+    var journalEntrySave: String            { s("保存今日日记",      "Save Today's Journal",         "今日の日記を保存") }
+    var journalEntryEdit: String            { s("编辑",             "Edit",                         "編集") }
+    var journalEntryOnceADay: String        { s("每天只能记录一次",   "One entry per day",            "1日1回のみ記録できます") }
+    var journalEntryTodayTitle: String      { s("今日日记",          "Today's Journal",              "今日の日記") }
+    var journalEntrySharedBadge: String     { s("已分享",            "Shared",                       "シェア済み") }
+    var journalEntryPrivateBadge: String    { s("仅自己",            "Private",                      "非公開") }
+    var journalEntryWritePrompt: String     { s("记录今天的心情与收获", "Record today's mood & gains", "今日の気分と収穫を記録") }
+    var journalEntryWriteHint: String       { s("每天一次，留下属于今天的印记",
+                                                 "Once a day — leave a mark for today",
+                                                 "1日1回、今日の足跡を残しましょう") }
+
     // MARK: FeedbackView
     var feedbackNavTitle: String        { s("功能建议",             "Feature Feedback",         "機能フィードバック") }
     var feedbackSectionTitle: String    { s("反馈与建议",            "Feedback",                 "フィードバック") }

--- a/Cathier/Models/DailyJournal.swift
+++ b/Cathier/Models/DailyJournal.swift
@@ -1,0 +1,94 @@
+import Foundation
+import SwiftData
+
+// MARK: - Mood Enum
+
+enum DailyMood: String, CaseIterable, Identifiable {
+    case veryHappy = "veryHappy"
+    case good      = "good"
+    case okay      = "okay"
+    case notGreat  = "notGreat"
+    case bad       = "bad"
+
+    var id: String { rawValue }
+
+    var emoji: String {
+        switch self {
+        case .veryHappy: return "😄"
+        case .good:      return "😊"
+        case .okay:      return "😐"
+        case .notGreat:  return "😔"
+        case .bad:       return "😢"
+        }
+    }
+
+    func label(for language: AppLanguage) -> String {
+        switch language {
+        case .zh: return labelZh
+        case .en: return labelEn
+        case .ja: return labelJa
+        }
+    }
+
+    private var labelZh: String {
+        switch self {
+        case .veryHappy: return "很开心"
+        case .good:      return "不错"
+        case .okay:      return "还好"
+        case .notGreat:  return "不太好"
+        case .bad:       return "很难过"
+        }
+    }
+
+    private var labelEn: String {
+        switch self {
+        case .veryHappy: return "Very Happy"
+        case .good:      return "Good"
+        case .okay:      return "Okay"
+        case .notGreat:  return "Not Great"
+        case .bad:       return "Sad"
+        }
+    }
+
+    private var labelJa: String {
+        switch self {
+        case .veryHappy: return "とても幸せ"
+        case .good:      return "良い"
+        case .okay:      return "まあまあ"
+        case .notGreat:  return "あまりよくない"
+        case .bad:       return "悲しい"
+        }
+    }
+}
+
+// MARK: - DailyJournal Model
+
+@Model
+final class DailyJournal {
+    var id: UUID = UUID()
+    /// Creation date; day component is used to enforce one entry per day.
+    var date: Date = Date()
+    /// Stores `DailyMood.rawValue`.
+    var mood: String = ""
+    /// Today's gains, learnings, or reflections.
+    var gains: String = ""
+    /// Whether the entry is shared with friends.
+    var isShared: Bool = false
+
+    init(
+        date: Date = Date(),
+        mood: String,
+        gains: String,
+        isShared: Bool = false
+    ) {
+        self.id = UUID()
+        self.date = date
+        self.mood = mood
+        self.gains = gains
+        self.isShared = isShared
+    }
+
+    var dailyMood: DailyMood? {
+        DailyMood(rawValue: mood)
+    }
+}

--- a/Cathier/Views/Components/DailyJournalCard.swift
+++ b/Cathier/Views/Components/DailyJournalCard.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct DailyJournalCard: View {
+    let journal: DailyJournal
+    @Environment(LanguageManager.self) private var lm
+    var onEdit: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header row: mood emoji + privacy badge + edit button
+            HStack(alignment: .center, spacing: 8) {
+                if let mood = journal.dailyMood {
+                    Text(mood.emoji)
+                        .font(.system(size: 32))
+                    Text(mood.label(for: lm.currentLanguage))
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                }
+                Spacer()
+                // Privacy badge
+                Label(
+                    journal.isShared ? lm.journalEntrySharedBadge : lm.journalEntryPrivateBadge,
+                    systemImage: journal.isShared ? "person.2.fill" : "lock.fill"
+                )
+                .font(.caption)
+                .foregroundColor(journal.isShared ? .orange : .secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    (journal.isShared ? Color.orange : Color.secondary)
+                        .opacity(0.1)
+                )
+                .clipShape(Capsule())
+
+                if let edit = onEdit {
+                    Button(action: edit) {
+                        Image(systemName: "pencil.circle.fill")
+                            .font(.title3)
+                            .foregroundColor(.orange.opacity(0.8))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            // Gains text
+            if !journal.gains.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(journal.gains)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                    .lineLimit(4)
+                    .lineSpacing(2)
+            }
+        }
+        .padding(16)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(16)
+    }
+}

--- a/Cathier/Views/DailyJournalEntryView.swift
+++ b/Cathier/Views/DailyJournalEntryView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+import SwiftData
+
+struct DailyJournalEntryView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+    @Environment(LanguageManager.self) private var lm
+    @Environment(FriendViewModel.self) private var friendVM
+
+    /// Pass in an existing entry to edit it; nil to create a new one.
+    var existing: DailyJournal? = nil
+
+    let onSave: () -> Void
+
+    @State private var selectedMood: DailyMood? = nil
+    @State private var gains: String = ""
+    @State private var isShared: Bool = false
+
+    private var hasFriends: Bool {
+        friendVM.currentProfile != nil && !friendVM.friends.isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    moodSection
+                    gainsSection
+                    if hasFriends {
+                        shareSection
+                    }
+                    saveButton
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 24)
+            }
+            .navigationTitle(lm.journalEntryNavTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(lm.checkInCancel) { dismiss() }
+                }
+            }
+        }
+        .onAppear {
+            if let entry = existing {
+                selectedMood = entry.dailyMood
+                gains = entry.gains
+                isShared = entry.isShared
+            }
+        }
+    }
+
+    // MARK: - Mood Picker
+
+    private var moodSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(lm.journalEntryMoodLabel)
+                .font(.headline)
+
+            HStack(spacing: 0) {
+                ForEach(DailyMood.allCases) { mood in
+                    moodButton(mood)
+                }
+            }
+            .padding(4)
+            .background(Color(.systemGray6))
+            .cornerRadius(16)
+        }
+    }
+
+    private func moodButton(_ mood: DailyMood) -> some View {
+        let isSelected = selectedMood == mood
+        return Button(action: { selectedMood = mood }) {
+            VStack(spacing: 4) {
+                Text(mood.emoji)
+                    .font(.system(size: 30))
+                Text(mood.label(for: lm.currentLanguage))
+                    .font(.caption2)
+                    .fontWeight(isSelected ? .semibold : .regular)
+                    .foregroundColor(isSelected ? .primary : .secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(
+                isSelected
+                    ? Color.orange.opacity(0.15)
+                    : Color.clear
+            )
+            .cornerRadius(12)
+            .overlay(
+                isSelected
+                    ? RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.orange.opacity(0.4), lineWidth: 1)
+                    : nil
+            )
+        }
+        .buttonStyle(.plain)
+        .animation(.easeInOut(duration: 0.15), value: selectedMood)
+    }
+
+    // MARK: - Gains Input
+
+    private var gainsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(lm.journalEntryGainsLabel)
+                .font(.headline)
+
+            TextField(lm.journalEntryGainsPlaceholder,
+                      text: $gains,
+                      axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(4...8)
+                .padding(14)
+                .background(Color(.systemGray6))
+                .cornerRadius(12)
+        }
+    }
+
+    // MARK: - Share Toggle
+
+    private var shareSection: some View {
+        Toggle(isOn: $isShared) {
+            HStack(spacing: 10) {
+                Image(systemName: "person.2.fill")
+                    .foregroundColor(.orange)
+                    .frame(width: 20)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(lm.journalEntryShareLabel)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                    Text(lm.journalEntryShareDesc)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .tint(.orange)
+        .padding(14)
+        .background(Color(.secondarySystemBackground))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Save
+
+    private var saveButton: some View {
+        Button(action: saveEntry) {
+            Text(lm.journalEntrySave)
+                .font(.headline)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+        }
+        .background(
+            selectedMood != nil
+                ? Color.orange
+                : Color.gray.opacity(0.4)
+        )
+        .cornerRadius(14)
+        .disabled(selectedMood == nil)
+        .animation(.easeInOut(duration: 0.2), value: selectedMood != nil)
+    }
+
+    private func saveEntry() {
+        guard let mood = selectedMood else { return }
+
+        if let entry = existing {
+            entry.mood = mood.rawValue
+            entry.gains = gains
+            entry.isShared = isShared
+        } else {
+            let journal = DailyJournal(
+                date: Date(),
+                mood: mood.rawValue,
+                gains: gains,
+                isShared: isShared
+            )
+            modelContext.insert(journal)
+        }
+
+        try? modelContext.save()
+        onSave()
+        dismiss()
+    }
+}

--- a/Cathier/Views/TodayView.swift
+++ b/Cathier/Views/TodayView.swift
@@ -3,11 +3,18 @@ import SwiftData
 
 struct TodayView: View {
     @Query(sort: \CheckIn.date, order: .reverse) private var checkIns: [CheckIn]
+    @Query(sort: \DailyJournal.date, order: .reverse) private var journals: [DailyJournal]
     @State private var showingCheckIn = false
+    @State private var showingJournalEntry = false
+    @State private var journalToEdit: DailyJournal? = nil
     @Environment(LanguageManager.self) private var lm
 
     private var todayCheckIns: [CheckIn] {
         checkIns.filter { Calendar.current.isDateInToday($0.date) }
+    }
+
+    private var todayJournal: DailyJournal? {
+        journals.first { Calendar.current.isDateInToday($0.date) }
     }
 
     var body: some View {
@@ -36,6 +43,10 @@ struct TodayView: View {
                         }
                     }
 
+                    // Daily journal section
+                    dailyJournalSection
+                        .padding(.horizontal, 20)
+
                     Spacer(minLength: 40)
                 }
                 .padding(.top, 8)
@@ -44,7 +55,66 @@ struct TodayView: View {
             .sheet(isPresented: $showingCheckIn) {
                 CheckInFlowView()
             }
+            .sheet(isPresented: $showingJournalEntry) {
+                DailyJournalEntryView(existing: journalToEdit) {
+                    journalToEdit = nil
+                }
+            }
         }
+    }
+
+    // MARK: - Daily Journal Section
+
+    @ViewBuilder
+    private var dailyJournalSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(lm.journalEntryTodayTitle)
+                .font(.headline)
+
+            if let journal = todayJournal {
+                DailyJournalCard(journal: journal) {
+                    journalToEdit = journal
+                    showingJournalEntry = true
+                }
+            } else {
+                journalWritePrompt
+            }
+        }
+    }
+
+    private var journalWritePrompt: some View {
+        Button(action: {
+            journalToEdit = nil
+            showingJournalEntry = true
+        }) {
+            HStack(spacing: 14) {
+                ZStack {
+                    Circle()
+                        .fill(Color(red: 0.4, green: 0.6, blue: 1.0).opacity(0.15))
+                        .frame(width: 48, height: 48)
+                    Image(systemName: "book.fill")
+                        .font(.system(size: 22))
+                        .foregroundColor(Color(red: 0.4, green: 0.6, blue: 1.0))
+                }
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(lm.journalEntryWritePrompt)
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.primary)
+                    Text(lm.journalEntryWriteHint)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(16)
+            .background(Color(.secondarySystemBackground))
+            .cornerRadius(16)
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Header


### PR DESCRIPTION
- New DailyJournal SwiftData model with mood (5-level emoji picker), gains text, and isShared flag; one entry per day enforced via today-filter in TodayView
- DailyJournalEntryView sheet: mood picker, gains textarea, optional share toggle (shown when user has friends), save button
- DailyJournalCard component displays existing entry with privacy badge and edit shortcut
- TodayView updated to show journal section below body-scan CTA; prompt when no entry yet, card when entry exists
- Full tri-lingual strings added (zh/en/ja) in LanguageManager
- DailyJournal added to ModelContainer and ContentView preview

Closes #16