### PR TITLE
feat: merge add-friend button into the friend activity feed

### DIFF
--- a/Cathier/Views/Friend/FriendFeedView.swift
+++ b/Cathier/Views/Friend/FriendFeedView.swift
@@ -68,6 +68,8 @@ private struct FriendHomeView: View {
     @Query(filter: #Predicate<DailyJournal> { $0.isShared }, sort: \DailyJournal.date, order: .reverse)
     private var sharedJournals: [DailyJournal]
 
+    @State private var showInviteView = false
+
     private var hasFeedContent: Bool {
         !vm.friendCheckIns.isEmpty || !sharedJournals.isEmpty
     }
@@ -91,6 +93,9 @@ private struct FriendHomeView: View {
                     Image(systemName: "person.2.fill")
                 }
             }
+        }
+        .sheet(isPresented: $showInviteView) {
+            NavigationStack { InviteView() }
         }
         .refreshable { await vm.loadFriendsAndFeed() }
     }
@@ -126,6 +131,24 @@ private struct FriendHomeView: View {
     private var friendAvatarRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 16) {
+                // Add friend button inline with avatars
+                Button(action: { showInviteView = true }) {
+                    VStack(spacing: 4) {
+                        Image(systemName: "person.badge.plus")
+                            .font(.system(size: 22))
+                            .foregroundColor(.orange)
+                            .frame(width: 52, height: 52)
+                            .background(Color.orange.opacity(0.12))
+                            .clipShape(Circle())
+                        Text(lm.manageInviteAction)
+                            .font(.caption2)
+                            .foregroundColor(.orange)
+                            .lineLimit(1)
+                            .frame(width: 52)
+                    }
+                }
+                .buttonStyle(.plain)
+
                 ForEach(vm.friends) { friend in
                     VStack(spacing: 4) {
                         Text(friend.avatarEmoji)
@@ -168,12 +191,22 @@ private struct FriendHomeView: View {
     }
 
     private var emptyFeedView: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 20) {
             Text("💤")
                 .font(.system(size: 48))
             Text(lm.friendEmptyFeed)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
+            Button(action: { showInviteView = true }) {
+                Label(lm.manageInviteAction, systemImage: "person.badge.plus")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 12)
+                    .background(Color.orange)
+                    .cornerRadius(22)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Cathier/Views/Friend/FriendManageView.swift
+++ b/Cathier/Views/Friend/FriendManageView.swift
@@ -3,19 +3,11 @@ import SwiftUI
 struct FriendManageView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
-    @State private var showInviteView = false
     @State private var removingFriend: UserProfile?
     @State private var showRemoveAlert = false
 
     var body: some View {
         List {
-            Section {
-                Button(action: { showInviteView = true }) {
-                    Label(lm.manageInviteAction, systemImage: "person.badge.plus")
-                        .foregroundColor(.orange)
-                }
-            }
-
             if !vm.friends.isEmpty {
                 Section(lm.manageConnectedFriends(vm.friends.count)) {
                     ForEach(vm.friends) { friend in
@@ -56,9 +48,6 @@ struct FriendManageView: View {
         }
         .navigationTitle(lm.manageNavTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .sheet(isPresented: $showInviteView) {
-            NavigationStack { InviteView() }
-        }
         .alert(lm.manageDisconnectAlert(removingFriend?.displayName ?? ""), isPresented: $showRemoveAlert) {
             Button(lm.manageDisconnect, role: .destructive) {
                 if let friend = removingFriend {


### PR DESCRIPTION
Add inline '+' button to the friend avatar row in the feed so users can add friends without navigating to a separate screen. Also show the add-friend button in the empty-feed state. Remove the redundant add-friend section from FriendManageView (now only used for removing friends via the toolbar).

Fixes #21