### PR TITLE
feat: replace all cool colors with warm tones throughout the app

### DIFF
--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -339,7 +339,7 @@ struct IntensityBadge: View {
 
     private var intensityColor: Color {
         switch intensity {
-        case ..<4: return .green
+        case ..<4: return .yellow
         case ..<7: return .cathierAccent
         default:   return .red
         }

--- a/Cathier/Views/CheckIn/BodyScanView.swift
+++ b/Cathier/Views/CheckIn/BodyScanView.swift
@@ -134,7 +134,7 @@ private struct IntensitySlider: View {
     let intenseLabel: String
 
     private let gradient = LinearGradient(
-        colors: [.green, .yellow, .orange, .red],
+        colors: [.yellow, .orange, .cathierAccent, .red],
         startPoint: .leading,
         endPoint: .trailing
     )
@@ -153,7 +153,7 @@ private struct IntensitySlider: View {
 
     private var intensityColor: Color {
         switch value {
-        case ..<4: return .green
+        case ..<4: return .yellow
         case ..<7: return .orange
         default:   return .red
         }

--- a/Cathier/Views/Components/CheckInCard.swift
+++ b/Cathier/Views/Components/CheckInCard.swift
@@ -16,7 +16,7 @@ struct CheckInCard: View {
                     if checkIn.shareLevel != nil {
                         Image(systemName: "person.2.fill")
                             .font(.caption2)
-                            .foregroundColor(.green.opacity(0.8))
+                            .foregroundColor(.cathierAccent.opacity(0.8))
                     }
                     Spacer()
                     IntensityBadge(intensity: checkIn.intensity, label: lm.aiIntensityBadge(checkIn.intensity))

--- a/Cathier/Views/Components/CheckInDetailView.swift
+++ b/Cathier/Views/Components/CheckInDetailView.swift
@@ -40,14 +40,14 @@ struct CheckInDetailView: View {
                                 if !checkIn.bodyParts.isEmpty {
                                     FlowLayout(spacing: 8) {
                                         ForEach(checkIn.bodyParts, id: \.self) { part in
-                                            chip(lm.display(part), color: .blue)
+                                            chip(lm.display(part), color: .cathierAccent)
                                         }
                                     }
                                 }
                                 if !parsed.global.isEmpty {
                                     FlowLayout(spacing: 8) {
                                         ForEach(parsed.global, id: \.self) { s in
-                                            chip(lm.display(s), color: .teal)
+                                            chip(lm.display(s), color: .cathierAccent)
                                         }
                                     }
                                 }
@@ -58,10 +58,10 @@ struct CheckInDetailView: View {
                                         Text(lm.display(entry.part))
                                             .font(.caption)
                                             .fontWeight(.medium)
-                                            .foregroundColor(.blue)
+                                            .foregroundColor(.cathierAccent)
                                         FlowLayout(spacing: 6) {
                                             ForEach(entry.sensations, id: \.self) { s in
-                                                chip(lm.display(s), color: .teal)
+                                                chip(lm.display(s), color: .cathierAccent)
                                             }
                                         }
                                     }
@@ -69,7 +69,7 @@ struct CheckInDetailView: View {
                                 if !parsed.global.isEmpty {
                                     FlowLayout(spacing: 8) {
                                         ForEach(parsed.global, id: \.self) { s in
-                                            chip(lm.display(s), color: .teal)
+                                            chip(lm.display(s), color: .cathierAccent)
                                         }
                                     }
                                 }
@@ -174,7 +174,7 @@ struct CheckInDetailView: View {
             if isShared, let tier = currentTier {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(.cathierAccent)
                     Text(tier.displayName)
                         .font(.subheadline)
                     Text("·")
@@ -253,7 +253,7 @@ struct CheckInDetailView: View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: 14)
-                .stroke(isShared ? Color.green.opacity(0.3) : Color.clear, lineWidth: 1)
+                .stroke(isShared ? Color.cathierAccent.opacity(0.3) : Color.clear, lineWidth: 1)
         )
     }
 

--- a/Cathier/Views/Components/DailyJournalCard.swift
+++ b/Cathier/Views/Components/DailyJournalCard.swift
@@ -24,7 +24,7 @@ struct DailyJournalCard: View {
                     systemImage: journal.isShared ? "person.2.fill" : "lock.fill"
                 )
                 .font(.caption)
-                .foregroundColor(journal.isShared ? .cathierSage : .secondary)
+                .foregroundColor(journal.isShared ? .cathierAccent : .secondary)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(
@@ -37,7 +37,7 @@ struct DailyJournalCard: View {
                     Button(action: edit) {
                         Image(systemName: "pencil.circle.fill")
                             .font(.title3)
-                            .foregroundColor(.cathierSage.opacity(0.8))
+                            .foregroundColor(.cathierAccent.opacity(0.8))
                     }
                     .buttonStyle(.plain)
                 }

--- a/Cathier/Views/FeedbackView.swift
+++ b/Cathier/Views/FeedbackView.swift
@@ -36,7 +36,7 @@ struct FeedbackView: View {
                             .foregroundColor(.cathierAccent)
                     } header: {
                         Text(lm.feedbackSuccess)
-                            .foregroundColor(.green)
+                            .foregroundColor(.cathierAccent)
                     }
                 }
 

--- a/Cathier/Views/Friend/FriendFeedView.swift
+++ b/Cathier/Views/Friend/FriendFeedView.swift
@@ -156,13 +156,13 @@ private struct FriendHomeView: View {
                     VStack(spacing: 4) {
                         Image(systemName: "person.badge.plus")
                             .font(.system(size: 22))
-                            .foregroundColor(.cathierSage)
+                            .foregroundColor(.cathierAccent)
                             .frame(width: 52, height: 52)
-                            .background(Color.cathierSage.opacity(0.12))
+                            .background(Color.cathierAccent.opacity(0.12))
                             .clipShape(Circle())
                         Text(lm.manageAddFriend)
                             .font(.caption2)
-                            .foregroundColor(.cathierSage)
+                            .foregroundColor(.cathierAccent)
                             .lineLimit(1)
                             .frame(width: 52)
                     }
@@ -203,7 +203,7 @@ private struct FriendHomeView: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 28)
                     .padding(.vertical, 12)
-                    .background(Color.cathierSage)
+                    .background(Color.cathierAccent)
                     .clipShape(Capsule())
             }
         }
@@ -224,7 +224,7 @@ private struct FriendHomeView: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 28)
                     .padding(.vertical, 12)
-                    .background(Color.cathierSage)
+                    .background(Color.cathierAccent)
                     .clipShape(Capsule())
             }
         }
@@ -423,8 +423,8 @@ struct SharedJournalFeedRow: View {
                             .fontWeight(.medium)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
-                            .background(Color.cathierSageLight)
-                            .foregroundColor(Color.cathierSage)
+                            .background(Color.cathierAccentLight)
+                            .foregroundColor(Color.cathierAccent)
                             .clipShape(Capsule())
                     }
                     Text(journal.date.absoluteString)

--- a/Cathier/Views/TodayView.swift
+++ b/Cathier/Views/TodayView.swift
@@ -91,11 +91,11 @@ struct TodayView: View {
             HStack(spacing: 14) {
                 ZStack {
                     Circle()
-                        .fill(Color.cathierSage.opacity(0.15))
+                        .fill(Color.cathierAccent.opacity(0.15))
                         .frame(width: 48, height: 48)
                     Image(systemName: "book.fill")
                         .font(.system(size: 22))
-                        .foregroundColor(Color.cathierSage)
+                        .foregroundColor(Color.cathierAccent)
                 }
                 VStack(alignment: .leading, spacing: 3) {
                     Text(lm.journalEntryWritePrompt)


### PR DESCRIPTION
Replace green/blue/teal/sage colors with warm equivalents (cathierAccent orange and yellow) to maintain a consistent warm color palette:

- CheckInCard: share indicator green → cathierAccent
- CheckInDetailView: body part chips blue/teal → cathierAccent; share indicator green → cathierAccent; shared card border green → cathierAccent
- CheckInDetailView: shared state checkmark green → cathierAccent
- AIFeedbackView: low intensity badge green → yellow
- BodyScanView: intensity slider gradient starts yellow instead of green; low intensity color yellow instead of green
- FeedbackView: success message green → cathierAccent
- DailyJournalCard: shared badge and edit button sage → cathierAccent
- TodayView: journal shortcut icon sage → cathierAccent
- FriendFeedView: all sage/sageLight → cathierAccent/cathierAccentLight

Fixes #24