### PR TITLE
fix(friend): refresh pending requests when opening manage view and on foreground

### DIFF
--- a/Cathier/Views/Friend/FriendFeedView.swift
+++ b/Cathier/Views/Friend/FriendFeedView.swift
@@ -52,6 +52,7 @@ struct FriendFeedView: View {
 private struct FriendHomeView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
+    @Environment(\.scenePhase) private var scenePhase
     @Query(filter: #Predicate<DailyJournal> { $0.isShared }, sort: \DailyJournal.date, order: .reverse)
     private var sharedJournals: [DailyJournal]
 
@@ -96,6 +97,11 @@ private struct FriendHomeView: View {
             AddFriendView()
         }
         .refreshable { await vm.loadFriendsAndFeed() }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task { await vm.loadFriendsAndFeed() }
+            }
+        }
     }
 
     // Unified feed item merging check-ins and shared journals, sorted latest first.

--- a/Cathier/Views/Friend/FriendManageView.swift
+++ b/Cathier/Views/Friend/FriendManageView.swift
@@ -58,6 +58,8 @@ struct FriendManageView: View {
         }
         .navigationTitle(lm.manageNavTitle)
         .navigationBarTitleDisplayMode(.inline)
+        .task { await vm.loadFriendsAndFeed() }
+        .refreshable { await vm.loadFriendsAndFeed() }
         .alert(lm.manageDisconnectAlert(removingFriend?.displayName ?? ""), isPresented: $showRemoveAlert) {
             Button(lm.manageDisconnect, role: .destructive) {
                 if let friend = removingFriend {


### PR DESCRIPTION
FriendManageView never called loadFriendsAndFeed() on appear, so any
invite sent after the last refresh was invisible to the recipient.
Added .task and .refreshable to FriendManageView so data is always
fresh when the user opens it.

Also added scenePhase .active observer in FriendHomeView so the feed
and pending-request badge refresh whenever the app returns from
background.

https://claude.ai/code/session_01BhBbWrfnfwUSpxi8Nqy22t