### PR TITLE
feat: add 吃一堑长一智 feature with homepage entry

### DIFF
--- a/cathier-miniprogram/cloudfunctions/ai-proxy/index.js
+++ b/cathier-miniprogram/cloudfunctions/ai-proxy/index.js
@@ -24,6 +24,29 @@ const SYSTEM_PROMPT = `你是「觉察」小程序的AI觉察伙伴。这是一�
 
 风格：像练习过正念的朋友轻声说话。不评判，不说"你应该"。可以肯定觉察能力本身。每次变换结构和切入角度。不使用医疗术语。本小程序不提供医疗建议，AI反馈仅供参考。`
 
+const LESSON_CHAT_PROMPT = `你是「觉察」小程序的智慧对话伙伴，正在陪用户进行「吃一堑长一智」反思练习——帮助他们从一次挫折、失误或困惑中提炼智慧。
+
+你的角色：温和的苏格拉底式引导者。不说教，不评判，不给具体建议。通过好奇的提问，帮用户自己发现洞见。
+
+对话原则：
+- 每次只问一个问题，让对话保持聚焦
+- 帮用户区分「发生了什么」和「我从中学到了什么」
+- 在适当时机反映你观察到的模式（如"我注意到你两次提到了..."）
+- 回复控制在80字以内，简洁有力
+
+不要：给出具体解决方案、评判用户选择、使用心理学术语。`
+
+const LESSON_SUMMARY_PROMPT = `根据以下对话，请提炼3-7条「吃一堑长一智」的具体洞见。
+
+格式要求：
+- 每条独占一行，用数字编号（1. 2. 3.）
+- 每条20-50字，简洁有力，有具体内容
+- 使用第一人称（"我..."）
+- 从这次经历出发，到可迁移的原则
+- 避免空洞废话（如"我要更努力"）
+
+只输出编号列表，不要其他内容。`
+
 /**
  * Format body sensations object into readable text.
  * Input: { "胸口": ["紧绷","沉重"], "肩膀": ["酸痛"] }
@@ -139,6 +162,56 @@ function sleep(ms) {
 }
 
 /**
+ * Call Hunyuan with a full messages array (system + history).
+ */
+async function callHunyuanMessages(messages) {
+  const apiKey = process.env.HUNYUAN_API_KEY
+  if (!apiKey) {
+    return { success: false, error: 'AI服务配置错误，请联系开发者' }
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(HUNYUAN_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: HUNYUAN_MODEL,
+        messages,
+        temperature: 0.7,
+        max_tokens: 600
+      }),
+      signal: controller.signal
+    })
+
+    clearTimeout(timeout)
+
+    if (response.status === 401) return { success: false, error: 'AI服务配置错误，请联系开发者' }
+    if (response.status === 429) return { success: false, rateLimited: true }
+    if (!response.ok) {
+      return { success: false, fallback: true, feedback: 'AI反馈生成失败，请稍后重试。' }
+    }
+
+    const data = await response.json()
+    const feedbackText = data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content
+    if (!feedbackText) return { success: false, fallback: true, feedback: 'AI反馈生成失败，请稍后重试。' }
+
+    return { success: true, feedback: feedbackText.trim() }
+  } catch (err) {
+    clearTimeout(timeout)
+    if (err.name === 'AbortError') {
+      return { success: false, fallback: true, feedback: 'AI连接超时，请稍后重试。' }
+    }
+    return { success: false, fallback: true, feedback: 'AI反馈生成失败，请稍后重试。' }
+  }
+}
+
+/**
  * Main cloud function entry point.
  */
 exports.main = async (event, context) => {
@@ -148,7 +221,54 @@ exports.main = async (event, context) => {
     return { success: true, ping: true }
   }
 
-  // Validate required fields
+  // Pattern insights: custom system prompt + user prompt
+  if (event.type === 'pattern-insights') {
+    const messages = [
+      { role: 'system', content: event.systemPrompt || '' },
+      { role: 'user', content: event.userPrompt || '' }
+    ]
+    let result = await callHunyuanMessages(messages)
+    if (result.rateLimited) {
+      await sleep(1000)
+      result = await callHunyuanMessages(messages)
+    }
+    return result
+  }
+
+  // Lesson chat: multi-turn reflection conversation
+  if (event.type === 'lesson-chat') {
+    const history = event.history || []
+    const messages = [
+      { role: 'system', content: LESSON_CHAT_PROMPT },
+      ...history
+    ]
+    let result = await callHunyuanMessages(messages)
+    if (result.rateLimited) {
+      await sleep(1000)
+      result = await callHunyuanMessages(messages)
+    }
+    return result
+  }
+
+  // Lesson summary: extract 3-7 learnings from conversation
+  if (event.type === 'lesson-summary') {
+    const history = event.history || []
+    const conversationText = history
+      .map(m => `${m.role === 'assistant' ? 'AI' : '用户'}：${m.content}`)
+      .join('\n')
+    const messages = [
+      { role: 'system', content: LESSON_SUMMARY_PROMPT },
+      { role: 'user', content: `对话内容：\n${conversationText}` }
+    ]
+    let result = await callHunyuanMessages(messages)
+    if (result.rateLimited) {
+      await sleep(1000)
+      result = await callHunyuanMessages(messages)
+    }
+    return result
+  }
+
+  // Default: check-in feedback (original flow)
   if (!event.emotions || !event.bodySensations) {
     console.log('Missing required fields: emotions or bodySensations')
     return { success: false, error: '缺少必要的觉察数据' }

--- a/cathier-miniprogram/miniprogram/app.json
+++ b/cathier-miniprogram/miniprogram/app.json
@@ -14,7 +14,8 @@
     "pages/webview/webview",
     "pages/friends/friends",
     "pages/add-friend/add-friend",
-    "pages/friend-manage/friend-manage"
+    "pages/friend-manage/friend-manage",
+    "pages/lesson-chat/lesson-chat"
   ],
   "tabBar": {
     "color": "#8B8B8B",

--- a/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.js
+++ b/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.js
@@ -1,0 +1,133 @@
+const { saveLessonSummary } = require('../../utils/cloud-db')
+
+const INITIAL_MESSAGE = '最近有什么让你感触深刻的经历、挫折或遗憾吗？不妨从那里开始聊聊。'
+
+Page({
+  data: {
+    messages: [],
+    inputText: '',
+    loading: false,
+    canSummarize: false,
+    showSummary: false,
+    summaryItems: [],
+    saved: false,
+    sendable: false,
+    scrollToMsg: ''
+  },
+
+  onLoad() {
+    this.setData({
+      messages: [
+        { role: 'ai', content: INITIAL_MESSAGE, id: 'init' }
+      ]
+    })
+  },
+
+  onInput(e) {
+    const val = e.detail.value || ''
+    this.setData({ inputText: val, sendable: val.trim().length > 0 })
+  },
+
+  async onSend() {
+    const text = this.data.inputText.trim()
+    if (!text || this.data.loading) return
+
+    const userMsg = { role: 'user', content: text, id: 'u' + Date.now() }
+    const newMessages = [...this.data.messages, userMsg]
+    const userTurnCount = newMessages.filter(m => m.role === 'user').length
+
+    this.setData({
+      messages: newMessages,
+      inputText: '',
+      sendable: false,
+      loading: true,
+      scrollToMsg: userMsg.id
+    })
+
+    try {
+      const history = newMessages.map(m => ({
+        role: m.role === 'ai' ? 'assistant' : 'user',
+        content: m.content
+      }))
+
+      const result = await wx.cloud.callFunction({
+        name: 'ai-proxy',
+        data: { type: 'lesson-chat', history, turnCount: userTurnCount },
+        timeout: 30000
+      })
+
+      const reply = (result.result && result.result.feedback) || '我在听，请继续分享。'
+      const aiMsg = { role: 'ai', content: reply, id: 'a' + Date.now() }
+
+      this.setData({
+        messages: [...this.data.messages, aiMsg],
+        loading: false,
+        canSummarize: userTurnCount >= 3,
+        scrollToMsg: aiMsg.id
+      })
+    } catch (err) {
+      console.error('Lesson chat error:', err)
+      const errMsg = { role: 'ai', content: '连接失败，请稍后重试。', id: 'a' + Date.now() }
+      this.setData({ messages: [...this.data.messages, errMsg], loading: false })
+    }
+  },
+
+  async onSummarize() {
+    if (this.data.loading) return
+    this.setData({ loading: true })
+
+    const history = this.data.messages.map(m => ({
+      role: m.role === 'ai' ? 'assistant' : 'user',
+      content: m.content
+    }))
+
+    try {
+      const result = await wx.cloud.callFunction({
+        name: 'ai-proxy',
+        data: { type: 'lesson-summary', history },
+        timeout: 30000
+      })
+
+      const raw = (result.result && result.result.feedback) || ''
+      const items = this._parseSummaryItems(raw)
+
+      this.setData({ loading: false, showSummary: true, summaryItems: items })
+    } catch (err) {
+      console.error('Lesson summary error:', err)
+      this.setData({ loading: false })
+      wx.showToast({ title: '生成失败，请重试', icon: 'none' })
+    }
+  },
+
+  _parseSummaryItems(text) {
+    const lines = text.split('\n').filter(l => l.trim())
+    const items = []
+    for (const line of lines) {
+      const cleaned = line.replace(/^[\d]+[.、。\)\s]+/, '').trim()
+      if (cleaned.length > 5) items.push(cleaned)
+    }
+    return items.slice(0, 7)
+  },
+
+  async onSave() {
+    if (this.data.saved) return
+
+    try {
+      await saveLessonSummary({
+        items: this.data.summaryItems,
+        conversationLength: this.data.messages.filter(m => m.role === 'user').length,
+        date: new Date()
+      })
+      this.setData({ saved: true })
+      wx.showToast({ title: '已记录', icon: 'success' })
+      setTimeout(() => wx.navigateBack(), 1200)
+    } catch (err) {
+      console.error('Save lesson summary error:', err)
+      wx.showToast({ title: '保存失败，请重试', icon: 'none' })
+    }
+  },
+
+  onBack() {
+    wx.navigateBack()
+  }
+})

--- a/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.json
+++ b/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.json
@@ -1,0 +1,5 @@
+{
+  "navigationBarTitleText": "吃一堑长一智",
+  "navigationBarBackgroundColor": "#F5E6D3",
+  "navigationBarTextStyle": "black"
+}

--- a/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.wxml
+++ b/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.wxml
@@ -1,0 +1,84 @@
+<view class="container lesson-page">
+  <!-- Intro header -->
+  <view class="lesson-header">
+    <text class="lesson-title">吃一堑，长一智</text>
+    <text class="lesson-subtitle">通过对话，从经历中提炼智慧</text>
+  </view>
+
+  <!-- Summary view -->
+  <view class="summary-view" wx:if="{{showSummary}}">
+    <view class="summary-header">
+      <text class="summary-title-icon">✨</text>
+      <text class="summary-title-text">这次的收获</text>
+    </view>
+
+    <view class="summary-items">
+      <view class="summary-item" wx:for="{{summaryItems}}" wx:key="index">
+        <text class="summary-item-index">{{index + 1}}</text>
+        <text class="summary-item-text">{{item}}</text>
+      </view>
+    </view>
+
+    <view class="summary-empty" wx:if="{{summaryItems.length === 0}}">
+      <text class="text-muted">对话还需要更多内容，请继续聊聊。</text>
+    </view>
+
+    <button class="btn-primary save-btn" wx:if="{{summaryItems.length > 0 && !saved}}" bindtap="onSave">记录这些收获</button>
+    <view class="saved-hint" wx:if="{{saved}}">
+      <text class="text-muted">✓ 已保存</text>
+    </view>
+  </view>
+
+  <!-- Chat view -->
+  <view class="chat-view" wx:if="{{!showSummary}}">
+    <scroll-view class="msg-list" scroll-y scroll-into-view="{{scrollToMsg}}" scroll-with-animation>
+      <view class="msg-spacer"></view>
+
+      <view wx:for="{{messages}}" wx:key="id" id="{{item.id}}"
+            class="msg-row {{item.role === 'user' ? 'msg-row-user' : 'msg-row-ai'}}">
+        <view class="msg-bubble {{item.role === 'user' ? 'bubble-user' : 'bubble-ai'}}">
+          <text class="msg-text">{{item.content}}</text>
+        </view>
+      </view>
+
+      <!-- Loading indicator -->
+      <view class="msg-row msg-row-ai" wx:if="{{loading}}">
+        <view class="bubble-ai bubble-loading">
+          <view class="loading-dots">
+            <view class="dot"></view>
+            <view class="dot"></view>
+            <view class="dot"></view>
+          </view>
+        </view>
+      </view>
+
+      <view class="msg-bottom-pad"></view>
+    </scroll-view>
+
+    <!-- Input area -->
+    <view class="input-area">
+      <view class="summarize-hint" wx:if="{{canSummarize && !loading}}">
+        <text class="summarize-hint-text">聊得差不多了？</text>
+        <text class="summarize-link" bindtap="onSummarize">生成收获总结 →</text>
+      </view>
+
+      <view class="input-row">
+        <textarea
+          class="msg-input"
+          value="{{inputText}}"
+          placeholder="说说你的想法…"
+          placeholder-class="input-placeholder"
+          bindinput="onInput"
+          auto-height
+          maxlength="500"
+          confirm-type="send"
+          bindconfirm="onSend"
+          adjust-position
+        />
+        <view class="send-btn {{sendable && !loading ? 'send-btn-active' : 'send-btn-disabled'}}" bindtap="onSend">
+          <text class="send-icon">↑</text>
+        </view>
+      </view>
+    </view>
+  </view>
+</view>

--- a/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.wxss
+++ b/cathier-miniprogram/miniprogram/pages/lesson-chat/lesson-chat.wxss
@@ -1,0 +1,253 @@
+.lesson-page {
+  padding-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
+  padding-top: 0;
+}
+
+/* --- Header --- */
+
+.lesson-header {
+  padding: 60rpx var(--space-lg) var(--space-md);
+  flex-shrink: 0;
+}
+
+.lesson-title {
+  display: block;
+  font-size: 44rpx;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 8rpx;
+}
+
+.lesson-subtitle {
+  display: block;
+  font-size: 26rpx;
+  color: var(--text-muted);
+}
+
+/* --- Chat View --- */
+
+.chat-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.msg-list {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.msg-spacer {
+  height: var(--space-md);
+}
+
+.msg-bottom-pad {
+  height: 40rpx;
+}
+
+/* --- Message Rows --- */
+
+.msg-row {
+  display: flex;
+  padding: 12rpx var(--space-lg);
+}
+
+.msg-row-user {
+  justify-content: flex-end;
+}
+
+.msg-row-ai {
+  justify-content: flex-start;
+}
+
+/* --- Bubbles --- */
+
+.msg-bubble {
+  max-width: 75%;
+  padding: 24rpx 28rpx;
+  border-radius: 24rpx;
+  line-height: 1.6;
+}
+
+.bubble-ai {
+  background-color: var(--surface);
+  border-radius: 8rpx 24rpx 24rpx 24rpx;
+  box-shadow: 0 2rpx 8rpx rgba(26, 22, 19, 0.06);
+}
+
+.bubble-user {
+  background-color: var(--accent);
+  border-radius: 24rpx 8rpx 24rpx 24rpx;
+}
+
+.msg-text {
+  font-size: 30rpx;
+  line-height: 1.65;
+}
+
+.bubble-ai .msg-text {
+  color: var(--text-primary);
+}
+
+.bubble-user .msg-text {
+  color: #FFFFFF;
+}
+
+.bubble-loading {
+  padding: 20rpx 28rpx;
+  min-width: 80rpx;
+}
+
+/* --- Input Area --- */
+
+.input-area {
+  flex-shrink: 0;
+  padding: var(--space-sm) var(--space-lg) var(--space-xl);
+  background-color: var(--bg);
+  border-top: 1rpx solid var(--border);
+}
+
+.summarize-hint {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+  padding: 16rpx 0;
+}
+
+.summarize-hint-text {
+  font-size: 26rpx;
+  color: var(--text-muted);
+}
+
+.summarize-link {
+  font-size: 26rpx;
+  color: var(--accent);
+  font-weight: 500;
+}
+
+.input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-sm);
+  background-color: var(--surface);
+  border-radius: var(--radius-medium);
+  padding: 16rpx;
+  box-shadow: 0 2rpx 8rpx rgba(26, 22, 19, 0.06);
+}
+
+.msg-input {
+  flex: 1;
+  font-size: 30rpx;
+  color: var(--text-primary);
+  background: transparent;
+  line-height: 1.6;
+  min-height: 56rpx;
+  max-height: 200rpx;
+}
+
+.input-placeholder {
+  color: var(--text-muted);
+  font-size: 30rpx;
+}
+
+.send-btn {
+  width: 72rpx;
+  height: 72rpx;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease;
+}
+
+.send-btn-active {
+  background-color: var(--accent);
+}
+
+.send-btn-disabled {
+  background-color: var(--border);
+}
+
+.send-icon {
+  font-size: 32rpx;
+  font-weight: 700;
+  color: #FFFFFF;
+  line-height: 1;
+}
+
+/* --- Summary View --- */
+
+.summary-view {
+  flex: 1;
+  padding: 0 var(--space-lg) var(--space-3xl);
+  overflow-y: auto;
+}
+
+.summary-header {
+  display: flex;
+  align-items: center;
+  gap: 12rpx;
+  margin-bottom: var(--space-lg);
+}
+
+.summary-title-icon {
+  font-size: 36rpx;
+}
+
+.summary-title-text {
+  font-size: 36rpx;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.summary-items {
+  margin-bottom: var(--space-xl);
+}
+
+.summary-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 24rpx;
+  padding: var(--space-md);
+  background-color: var(--surface);
+  border-radius: var(--radius-medium);
+  margin-bottom: var(--space-sm);
+  box-shadow: 0 2rpx 8rpx rgba(26, 22, 19, 0.05);
+}
+
+.summary-item-index {
+  font-size: 28rpx;
+  font-weight: 700;
+  color: var(--accent);
+  min-width: 32rpx;
+  line-height: 1.6;
+  flex-shrink: 0;
+}
+
+.summary-item-text {
+  font-size: 30rpx;
+  color: var(--text-primary);
+  line-height: 1.65;
+  flex: 1;
+}
+
+.save-btn {
+  margin-top: var(--space-md);
+}
+
+.saved-hint {
+  text-align: center;
+  padding: var(--space-md);
+}
+
+.summary-empty {
+  text-align: center;
+  padding: var(--space-xl);
+}

--- a/cathier-miniprogram/miniprogram/pages/today/today.js
+++ b/cathier-miniprogram/miniprogram/pages/today/today.js
@@ -184,6 +184,12 @@ Page({
     })
   },
 
+  onOpenLessonChat() {
+    wx.navigateTo({
+      url: '/pages/lesson-chat/lesson-chat'
+    })
+  },
+
   onOpenSettings() {
     wx.navigateTo({
       url: '/pages/settings/settings'

--- a/cathier-miniprogram/miniprogram/pages/today/today.wxml
+++ b/cathier-miniprogram/miniprogram/pages/today/today.wxml
@@ -58,6 +58,18 @@
     </view>
   </view>
 
+  <!-- 吃一堑长一智 Entry -->
+  <view class="lesson-entry" bindtap="onOpenLessonChat" hover-class="lesson-entry-active">
+    <view class="lesson-entry-left">
+      <text class="lesson-entry-icon">🌱</text>
+      <view class="lesson-entry-text">
+        <text class="lesson-entry-title">吃一堑，长一智</text>
+        <text class="lesson-entry-sub">从挫折或遗憾中提炼智慧</text>
+      </view>
+    </view>
+    <text class="lesson-entry-arrow">→</text>
+  </view>
+
   <!-- Daily Journal -->
   <view class="journal-section">
     <text class="section-title">今日收获</text>

--- a/cathier-miniprogram/miniprogram/pages/today/today.wxss
+++ b/cathier-miniprogram/miniprogram/pages/today/today.wxss
@@ -227,6 +227,57 @@
   overflow: hidden;
 }
 
+/* --- 吃一堑长一智 Entry --- */
+
+.lesson-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--surface);
+  border-radius: var(--radius-medium);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+  box-shadow: 0 2rpx 12rpx rgba(26, 22, 19, 0.05),
+              0 1rpx 3rpx rgba(26, 22, 19, 0.03);
+}
+
+.lesson-entry-active {
+  background-color: var(--surface-alt);
+}
+
+.lesson-entry-left {
+  display: flex;
+  align-items: center;
+  gap: 24rpx;
+}
+
+.lesson-entry-icon {
+  font-size: 44rpx;
+  flex-shrink: 0;
+}
+
+.lesson-entry-text {
+  display: flex;
+  flex-direction: column;
+  gap: 6rpx;
+}
+
+.lesson-entry-title {
+  font-size: 30rpx;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.lesson-entry-sub {
+  font-size: 24rpx;
+  color: var(--text-muted);
+}
+
+.lesson-entry-arrow {
+  font-size: 32rpx;
+  color: var(--text-muted);
+}
+
 /* --- Daily Journal Section --- */
 
 .journal-section {

--- a/cathier-miniprogram/miniprogram/utils/cloud-db.js
+++ b/cathier-miniprogram/miniprogram/utils/cloud-db.js
@@ -199,6 +199,29 @@ async function updateShareLevel(checkinId, shareLevel) {
   })
 }
 
+// --- Lesson Summaries (吃一堑长一智) ---
+
+async function saveLessonSummary({ items, conversationLength, date }) {
+  const result = await db.collection('lesson_summaries').add({
+    data: {
+      items: items || [],
+      summary: (items || []).join('\n'),
+      conversationLength: conversationLength || 0,
+      date: date || db.serverDate(),
+      createdAt: db.serverDate()
+    }
+  })
+  return { _id: result._id, items }
+}
+
+async function getLessonSummaries(limit = 20) {
+  const result = await db.collection('lesson_summaries')
+    .orderBy('createdAt', 'desc')
+    .limit(limit)
+    .get()
+  return result.data || []
+}
+
 module.exports = {
   saveCheckIn,
   getCheckIns,
@@ -215,5 +238,7 @@ module.exports = {
   getCheckInCount,
   saveProfile,
   getMyProfile,
-  updateShareLevel
+  updateShareLevel,
+  saveLessonSummary,
+  getLessonSummaries
 }


### PR DESCRIPTION
- New lesson-chat page: multi-round AI reflection conversation that guides users to extract wisdom from a past setback or mistake
- After ≥3 user turns, a "生成收获总结" button appears to distill 3-7 key learnings from the conversation
- Summary items are saved to a new `lesson_summaries` collection
- Homepage (今日) gets a card entry point below today's check-ins
- ai-proxy cloud function extended with lesson-chat and lesson-summary routing types; also fixes pattern-insights handler that was missing
- cloud-db.js adds saveLessonSummary / getLessonSummaries helpers