### PR TITLE
fix: reopen TestFlight train (1.9→2.0) and bump immediately after release

### DIFF
--- a/Cathier.xcodeproj/project.pbxproj
+++ b/Cathier.xcodeproj/project.pbxproj
@@ -452,7 +452,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wangjianshuo.cathier.Cathier;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -488,7 +488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wangjianshuo.cathier.Cathier;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;


### PR DESCRIPTION
## Summary
Two related fixes — the immediate symptom and the structural cause.

### 1. Immediate fix: bump MARKETING_VERSION 1.9 → 2.0
Apple closed the 1.9 pre-release train after the auto-release lane shipped 1.9 to App Store review. Every TestFlight upload since failed at altool with `Invalid Pre-Release Train` / `must contain a higher version`. Bumping to 2.0 reopens uploads.

### 2. Structural fix: bump immediately after release in \`fastlane/Fastfile\`
Previously the auto-release lane bumped the version once per 10 builds (inside the release flow itself) and committed the just-released version (e.g. 1.9) back to main. Once Apple approved 1.9 the pre-release train closed, and every non-release TestFlight upload between releases (the next 9 builds) failed with the same train-closed error.

The release lane now does a second bump *after* submission and commits **that** version back to main:

\`\`\`
build N (multiple of 10):
  bump 1.8 → 1.9          (in-memory pbxproj on the runner)
  build & sign at 1.9
  upload_to_app_store(1.9)
  tag release/1.9
  bump 1.9 → 2.0          (on the runner)
  commit "chore: bump to 2.0 after release/1.9 [skip ci]" → main
\`\`\`

So main jumps **1.8 → 2.0**, skipping a committed 1.9 snapshot. The \`release/1.9\` tag still preserves a snapshot of the pbxproj at the released version. Subsequent TestFlight builds (N+1, N+2…) upload to the fresh 2.0 train cleanly.

Helper \`commit_and_push_version_bump\` simplified to take a custom \`message:\` argument; the old \`(version:, build_num:)\` signature was no longer accurate now that the committed version doesn't correspond to the just-built build number.

## Test plan
- [ ] CI Build & Deploy stays green on this branch (PR-only, no upload step)
- [ ] After merge: next push to main runs \`fastlane beta\` and the TestFlight upload at version 2.0 succeeds
- [ ] On the next 10th build, the post-release bump commit lands on main with message \`chore: bump to X.Y after release/A.B [skip ci]\` and the next TestFlight build picks up X.Y