### PR TITLE
feat: add 广场 (Plaza) feature — public emotional sharing space

### DIFF
--- a/Cathier/ContentView.swift
+++ b/Cathier/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct ContentView: View {
     @State private var friendVM = FriendViewModel()
+    @State private var plazaVM = PlazaViewModel()
     @State private var selectedTab = 0
     @Environment(LanguageManager.self) private var lm
     @Environment(ThemeManager.self) private var themeManager
@@ -21,13 +22,18 @@ struct ContentView: View {
                 FriendFeedView()
                     .onAppear { t("📱 FriendFeedView appeared") }
             }
-            Tab(lm.tabSettings, systemImage: "gearshape.fill", value: 3) {
+            Tab(lm.tabPlaza, systemImage: "person.3.fill", value: 3) {
+                PlazaView()
+                    .onAppear { t("📱 PlazaView appeared") }
+            }
+            Tab(lm.tabSettings, systemImage: "gearshape.fill", value: 4) {
                 SettingsView()
                     .onAppear { t("📱 SettingsView appeared") }
             }
         }
         .tint(themeManager.accentColor)
         .environment(friendVM)
+        .environment(plazaVM)
         .task { await friendVM.initialize() }
     }
 }

--- a/Cathier/Localization/Strings.swift
+++ b/Cathier/Localization/Strings.swift
@@ -8,6 +8,7 @@ extension LanguageManager {
     var tabToday: String    { localized("tab.today") }
     var tabJournal: String  { localized("tab.journal") }
     var tabFriends: String  { localized("tab.friends") }
+    var tabPlaza: String    { localized("tab.plaza") }
     var tabSettings: String { localized("tab.settings") }
 
     // MARK: TodayView
@@ -243,6 +244,17 @@ extension LanguageManager {
     // MARK: Notifications
     var notifMilestoneTitle: String { localized("notif.milestone_title") }
     var notifMilestoneBody: String  { localized("notif.milestone_body") }
+
+    // MARK: PlazaView
+    var plazaNavTitle: String          { localized("plaza.nav_title") }
+    var plazaEmpty: String             { localized("plaza.empty") }
+    var plazaEmptyHint: String         { localized("plaza.empty_hint") }
+    var plazaShareSectionTitle: String { localized("plaza.share_section_title") }
+    var plazaShareToggle: String       { localized("plaza.share_toggle") }
+    var plazaShareDesc: String         { localized("plaza.share_desc") }
+    var plazaTierCategoryDesc: String  { localized("plaza.tier_category_desc") }
+    var plazaTierEmotionsDesc: String  { localized("plaza.tier_emotions_desc") }
+    var plazaTierFullDesc: String      { localized("plaza.tier_full_desc") }
 
     // MARK: Error messages
     var claudeNoApiKey: String     { localized("error.no_api_key") }

--- a/Cathier/Models/CheckIn.swift
+++ b/Cathier/Models/CheckIn.swift
@@ -14,6 +14,8 @@ final class CheckIn {
     var triggerEvent: String = ""
     /// Mirrors FriendCheckIn.PrivacyTier.rawValue when shared; nil = private.
     var shareLevel: String? = nil
+    /// True when this check-in has been published to the public Plaza.
+    var isPlazaShared: Bool = false
 
     init(
         date: Date = Date(),

--- a/Cathier/Models/PlazaPost.swift
+++ b/Cathier/Models/PlazaPost.swift
@@ -1,0 +1,71 @@
+import CloudKit
+import Foundation
+
+/// A check-in publicly shared on the Plaza — visible to all users.
+struct PlazaPost: Identifiable {
+    static let recordType = "PlazaPost"
+
+    let id: CKRecord.ID
+    let ownerRef: CKRecord.Reference
+    let displayName: String
+    let avatarEmoji: String
+    let date: Date
+    let emotions: [String]
+    let bodyParts: [String]
+    let sensations: [String]
+    let intensity: Int
+    let aiFeedback: String
+    let privacyTier: FriendCheckIn.PrivacyTier
+
+    init(ownerProfile: UserProfile, checkIn: CheckIn, privacyTier: FriendCheckIn.PrivacyTier, shareAIFeedback: Bool = false) {
+        self.id = CKRecord.ID(recordName: "plaza_\(checkIn.id.uuidString)")
+        self.ownerRef = ownerProfile.reference
+        self.displayName = ownerProfile.displayName
+        self.avatarEmoji = ownerProfile.avatarEmoji
+        self.date = checkIn.date
+        self.emotions = checkIn.emotions
+        self.bodyParts = (privacyTier == .category) ? [] : checkIn.bodyParts
+        self.sensations = (privacyTier == .category) ? [] : checkIn.sensations
+        self.intensity = checkIn.intensity
+        self.aiFeedback = (privacyTier == .full || shareAIFeedback) ? checkIn.aiFeedback : ""
+        self.privacyTier = privacyTier
+    }
+
+    init?(record: CKRecord) {
+        guard record.recordType == Self.recordType,
+              let ownerRef = record["ownerRef"] as? CKRecord.Reference,
+              let displayName = record["displayName"] as? String,
+              let avatarEmoji = record["avatarEmoji"] as? String,
+              let date = record["date"] as? Date,
+              let emotions = record["emotions"] as? [String],
+              let tierRaw = record["privacyTier"] as? String,
+              let tier = FriendCheckIn.PrivacyTier(rawValue: tierRaw)
+        else { return nil }
+        self.id = record.recordID
+        self.ownerRef = ownerRef
+        self.displayName = displayName
+        self.avatarEmoji = avatarEmoji
+        self.date = date
+        self.emotions = emotions
+        self.bodyParts = record["bodyParts"] as? [String] ?? []
+        self.sensations = record["sensations"] as? [String] ?? []
+        self.intensity = (record["intensity"] as? Int64).map(Int.init) ?? 5
+        self.aiFeedback = record["aiFeedback"] as? String ?? ""
+        self.privacyTier = tier
+    }
+
+    func toRecord() -> CKRecord {
+        let record = CKRecord(recordType: Self.recordType, recordID: id)
+        record["ownerRef"] = ownerRef
+        record["displayName"] = displayName
+        record["avatarEmoji"] = avatarEmoji
+        record["date"] = date
+        record["emotions"] = emotions as CKRecordValue
+        record["bodyParts"] = bodyParts as CKRecordValue
+        record["sensations"] = sensations as CKRecordValue
+        record["intensity"] = Int64(intensity)
+        record["aiFeedback"] = aiFeedback
+        record["privacyTier"] = privacyTier.rawValue
+        return record
+    }
+}

--- a/Cathier/Services/CloudKitService.swift
+++ b/Cathier/Services/CloudKitService.swift
@@ -157,6 +157,28 @@ actor CloudKitService {
             .compactMap { FriendCheckIn(record: $0) }
     }
 
+    // MARK: - PlazaPost
+
+    func savePlazaPost(_ post: PlazaPost) async throws {
+        _ = try await db.save(post.toRecord())
+    }
+
+    func deletePlazaPost(id: CKRecord.ID) async throws {
+        _ = try await db.deleteRecord(withID: id)
+    }
+
+    /// Fetch most recent plaza posts.
+    /// ⚠️ Requires a Queryable index on `date` in CloudKit Dashboard:
+    ///    Schema → Record Types → PlazaPost → Add Index → Sortable → date
+    func fetchPlazaPosts(limit: Int = 50) async throws -> [PlazaPost] {
+        let query = CKQuery(recordType: PlazaPost.recordType, predicate: NSPredicate(value: true))
+        query.sortDescriptors = [NSSortDescriptor(key: "date", ascending: false)]
+        let (results, _) = try await db.records(matching: query, resultsLimit: limit)
+        return results
+            .compactMap { try? $0.1.get() }
+            .compactMap { PlazaPost(record: $0) }
+    }
+
     // MARK: - Reaction
 
     /// Save or overwrite a reaction (record name is deterministic — acts as upsert).

--- a/Cathier/ViewModels/PlazaViewModel.swift
+++ b/Cathier/ViewModels/PlazaViewModel.swift
@@ -1,0 +1,40 @@
+import CloudKit
+import Foundation
+import Observation
+
+@Observable
+final class PlazaViewModel {
+    var posts: [PlazaPost] = []
+    var isLoading = false
+    var error: String?
+
+    private let ck = CloudKitService.shared
+
+    func load(force: Bool = false) async {
+        guard force || !isLoading else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            posts = try await ck.fetchPlazaPosts()
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func post(_ plazaPost: PlazaPost) async throws {
+        try await ck.savePlazaPost(plazaPost)
+        if !posts.contains(where: { $0.id == plazaPost.id }) {
+            posts.insert(plazaPost, at: 0)
+        }
+    }
+
+    func remove(post: PlazaPost) async {
+        do {
+            try await ck.deletePlazaPost(id: post.id)
+            posts.removeAll { $0.id == post.id }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -12,10 +12,13 @@ struct AIFeedbackView: View {
     @AppStorage("lastShareTierRaw") private var lastShareTierRaw: String = FriendCheckIn.PrivacyTier.full.rawValue
     @State private var selectedTier: FriendCheckIn.PrivacyTier? = nil
     @State private var shareAIFeedback: Bool = false
+    @State private var shareToPlaza: Bool = false
+    @State private var plazaTier: FriendCheckIn.PrivacyTier = .emotions
     @State private var showExercise = false
     @State private var aiFeedbackCopied = false
 
     private var hasFriends: Bool { friendVM.currentProfile != nil && !friendVM.friends.isEmpty }
+    private var hasProfile: Bool { friendVM.currentProfile != nil }
 
     var body: some View {
         standardBody
@@ -48,6 +51,10 @@ struct AIFeedbackView: View {
 
                 if hasFriends {
                     shareSection
+                }
+
+                if hasProfile {
+                    plazaSection
                 }
 
                 Button(action: saveAction) {
@@ -221,6 +228,88 @@ struct AIFeedbackView: View {
         .tint(.cathierAccent)
     }
 
+    // MARK: - Plaza section
+
+    private var plazaSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "person.3.fill")
+                    .font(.caption)
+                    .foregroundColor(.cathierSage)
+                Text(lm.plazaShareSectionTitle)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+
+            VStack(spacing: 0) {
+                Toggle(isOn: $shareToPlaza) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "globe.asia.australia.fill")
+                            .foregroundColor(.cathierSage)
+                            .frame(width: 20)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(lm.plazaShareToggle)
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                            Text(lm.plazaShareDesc)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .tint(.cathierSage)
+                .padding(12)
+
+                if shareToPlaza {
+                    Divider().padding(.horizontal, 12)
+                    plazaTierPicker.padding(12)
+                }
+            }
+            .background(Color.cathierSageLight)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+    }
+
+    private var plazaTierPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(FriendCheckIn.PrivacyTier.allCases) { tier in
+                plazaTierRow(tier)
+                if tier != FriendCheckIn.PrivacyTier.allCases.last {
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func plazaTierRow(_ tier: FriendCheckIn.PrivacyTier) -> some View {
+        let isSelected = plazaTier == tier
+        return Button(action: { plazaTier = tier }) {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundColor(isSelected ? .cathierSage : .secondary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(tierDisplayName(tier))
+                        .font(.subheadline)
+                        .fontWeight(isSelected ? .medium : .regular)
+                        .foregroundColor(.primary)
+                    Text(plazaTierDescription(tier))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func plazaTierDescription(_ tier: FriendCheckIn.PrivacyTier) -> String {
+        switch tier {
+        case .category: return lm.plazaTierCategoryDesc
+        case .emotions: return lm.plazaTierEmotionsDesc
+        case .full:     return lm.plazaTierFullDesc
+        }
+    }
+
     // MARK: - History
 
     private func fetchRecentHistory() -> [CheckIn] {
@@ -260,6 +349,11 @@ struct AIFeedbackView: View {
         if let tier = selectedTier {
             let includeAI = tier == .full ? false : shareAIFeedback
             Task { try? await friendVM.shareCheckIn(checkIn, tier: tier, shareAIFeedback: includeAI) }
+        }
+        if shareToPlaza, let profile = friendVM.currentProfile {
+            let post = PlazaPost(ownerProfile: profile, checkIn: checkIn, privacyTier: plazaTier, shareAIFeedback: plazaTier == .full)
+            checkIn.isPlazaShared = true
+            Task { try? await CloudKitService.shared.savePlazaPost(post) }
         }
         onDismiss()
     }

--- a/Cathier/Views/Plaza/PlazaView.swift
+++ b/Cathier/Views/Plaza/PlazaView.swift
@@ -1,0 +1,363 @@
+import SwiftUI
+
+/// Entry point for the Plaza tab. Switches on account state.
+struct PlazaView: View {
+    @Environment(FriendViewModel.self) private var friendVM
+    @Environment(PlazaViewModel.self) private var plazaVM
+    @Environment(LanguageManager.self) private var lm
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                switch friendVM.accountState {
+                case .loading:
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                case .unavailable(let message):
+                    unavailableView(message)
+
+                case .needsProfile:
+                    FriendSetupView()
+
+                case .ready:
+                    PlazaFeedView()
+                }
+            }
+            .navigationTitle(lm.plazaNavTitle)
+            .navigationBarTitleDisplayMode(.large)
+        }
+    }
+
+    @ViewBuilder
+    private func unavailableView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "icloud.slash")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+            Button {
+                Task { await friendVM.retry() }
+            } label: {
+                Text(lm.friendRetry)
+                    .font(.subheadline)
+                    .foregroundColor(.cathierAccent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Feed (after profile setup)
+
+private struct PlazaFeedView: View {
+    @Environment(PlazaViewModel.self) private var plazaVM
+    @Environment(LanguageManager.self) private var lm
+    @Environment(\.scenePhase) private var scenePhase
+
+    var body: some View {
+        Group {
+            if plazaVM.isLoading && plazaVM.posts.isEmpty {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if plazaVM.posts.isEmpty {
+                emptyView
+            } else {
+                feedList
+            }
+        }
+        .task { await plazaVM.load() }
+        .refreshable { await plazaVM.load(force: true) }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task { await plazaVM.load() }
+            }
+        }
+    }
+
+    private var feedList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(plazaVM.posts) { post in
+                    PlazaPostCard(post: post)
+                }
+                Spacer(minLength: 24)
+            }
+        }
+    }
+
+    private var emptyView: some View {
+        VStack(spacing: 20) {
+            Text("🌏")
+                .font(.system(size: 56))
+            Text(lm.plazaEmpty)
+                .font(.headline)
+            Text(lm.plazaEmptyHint)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Plaza Post Card
+
+private struct PlazaPostCard: View {
+    let post: PlazaPost
+    @Environment(LanguageManager.self) private var lm
+    @State private var showFullAI = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            headerRow
+            emotionRow
+            if post.privacyTier != .category, !post.bodyParts.isEmpty {
+                bodyRow
+            }
+            if !post.aiFeedback.isEmpty {
+                aiSnippet
+            }
+        }
+        .padding(14)
+        .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(.horizontal, 20)
+        .padding(.vertical, 5)
+        .sheet(isPresented: $showFullAI) {
+            PlazaAIDetailView(post: post)
+        }
+    }
+
+    private var cardBackground: Color {
+        if let firstEmotion = post.emotions.first,
+           let category = EmotionData.category(for: firstEmotion) {
+            return category.color.opacity(0.08)
+        }
+        return Color(red: 0.878, green: 0.929, blue: 0.886)
+    }
+
+    private var headerRow: some View {
+        HStack(spacing: 10) {
+            Text(post.avatarEmoji)
+                .font(.system(size: 28))
+                .frame(width: 40, height: 40)
+                .background(Color(.systemGray5))
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(post.displayName)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                Text(post.date.plazaRelativeString)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            IntensityBadge(intensity: post.intensity, label: lm.aiIntensityBadge(post.intensity))
+        }
+    }
+
+    private var emotionRow: some View {
+        FlowLayout(spacing: 6) {
+            ForEach(visibleEmotions, id: \.self) { label in
+                let color: Color = (post.privacyTier == .category)
+                    ? .cathierSage
+                    : EmotionData.category(for: label)?.color ?? .cathierSage
+                Text(lm.display(label))
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(color.opacity(0.18))
+                    .foregroundColor(color)
+                    .clipShape(Capsule())
+            }
+        }
+    }
+
+    private var visibleEmotions: [String] {
+        switch post.privacyTier {
+        case .category:
+            var seen = Set<String>()
+            return post.emotions.compactMap { EmotionData.category(for: $0)?.nameZh }
+                .filter { seen.insert($0).inserted }
+        case .emotions, .full:
+            return post.emotions
+        }
+    }
+
+    private var bodyRow: some View {
+        let grouped = groupedSensations(post.sensations)
+        return VStack(alignment: .leading, spacing: 3) {
+            ForEach(post.bodyParts, id: \.self) { part in
+                HStack(alignment: .top, spacing: 5) {
+                    if part == post.bodyParts.first {
+                        Image(systemName: "figure.stand")
+                            .font(.caption2)
+                            .foregroundColor(.cathierSage)
+                            .frame(width: 12)
+                    } else {
+                        Spacer().frame(width: 12)
+                    }
+                    let sensations = grouped[part] ?? []
+                    let partName = lm.display(part)
+                    if sensations.isEmpty {
+                        Text(partName)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundColor(.cathierSage)
+                    } else {
+                        (Text(partName)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .foregroundColor(.cathierSage)
+                        + Text("  " + sensations.map { lm.display($0) }.joined(separator: " · "))
+                            .font(.caption)
+                            .foregroundColor(.secondary))
+                        .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+    }
+
+    private func groupedSensations(_ sensations: [String]) -> [String: [String]] {
+        var result: [String: [String]] = [:]
+        for s in sensations {
+            let parts = s.split(separator: ":", maxSplits: 1).map(String.init)
+            if parts.count == 2 {
+                result[parts[0], default: []].append(parts[1])
+            }
+        }
+        return result
+    }
+
+    private var aiSnippet: some View {
+        Button(action: { showFullAI = true }) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "sparkles")
+                    .font(.caption2)
+                    .foregroundColor(.cathierAccent)
+                    .padding(.top, 3)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(StructuredFeedback.parse(post.aiFeedback)?.previewText ?? post.aiFeedback.plazaFirstSentence)
+                        .font(.cathierSerif(.subheadline))
+                        .foregroundColor(.primary)
+                        .lineSpacing(2)
+                        .lineLimit(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(lm.aiReadMore)
+                        .font(.caption2)
+                        .foregroundColor(.cathierAccent)
+                }
+            }
+            .padding(10)
+            .background(Color.cathierAccentLight)
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.cathierAccent.opacity(0.15), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Plaza AI Detail Sheet
+
+struct PlazaAIDetailView: View {
+    let post: PlazaPost
+    @Environment(LanguageManager.self) private var lm
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack(spacing: 10) {
+                        Text(post.avatarEmoji)
+                            .font(.system(size: 28))
+                            .frame(width: 40, height: 40)
+                            .background(Color(.systemGray5))
+                            .clipShape(Circle())
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(post.displayName)
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            Text(post.date.plazaRelativeString)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    Group {
+                        if let structured = StructuredFeedback.parse(post.aiFeedback) {
+                            StructuredFeedbackView(feedback: structured)
+                        } else {
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: "sparkles")
+                                    .font(.subheadline)
+                                    .foregroundColor(.cathierAccent)
+                                    .padding(.top, 2)
+                                Text(post.aiFeedback)
+                                    .font(.cathierSerif(.body))
+                                    .foregroundColor(.primary)
+                                    .lineSpacing(4)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
+                    .padding(14)
+                    .background(Color.cathierAccentLight)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .stroke(Color.cathierAccent.opacity(0.15), lineWidth: 1)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                }
+                .padding(20)
+            }
+            .navigationTitle(lm.aiFullInterpretation)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button { dismiss() } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private extension Date {
+    var plazaRelativeString: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        formatter.doesRelativeDateFormatting = true
+        return formatter.string(from: self)
+    }
+}
+
+private extension String {
+    var plazaFirstSentence: String {
+        let terminators = CharacterSet(charactersIn: ".。!！?？\n")
+        if let range = unicodeScalars.indices.first(where: { terminators.contains(unicodeScalars[$0]) }) {
+            let endIndex = unicodeScalars.index(after: range)
+            return String(self[..<endIndex]).trimmingCharacters(in: .whitespaces)
+        }
+        return count > 120 ? String(prefix(120)) + "…" : self
+    }
+}

--- a/Cathier/ar.lproj/Localizable.strings
+++ b/Cathier/ar.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/de.lproj/Localizable.strings
+++ b/Cathier/de.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza\nLet kindred spirits find you";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/en.lproj/Localizable.strings
+++ b/Cathier/en.lproj/Localizable.strings
@@ -260,3 +260,15 @@
 "persona.journaler.desc" = "5-step method to reframe and act";
 "persona.brainTrainer.name" = "Eat a Lesson, Gain Wisdom";
 "persona.brainTrainer.desc" = "Five questions to retrain your cognitive defaults";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza\nLet kindred spirits find you";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/es.lproj/Localizable.strings
+++ b/Cathier/es.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza\nLet kindred spirits find you";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/fr.lproj/Localizable.strings
+++ b/Cathier/fr.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Place";
+"plaza.nav_title" = "Place";
+"plaza.empty" = "Rien de partagé encore";
+"plaza.empty_hint" = "Après votre check-in, partagez vos émotions à la Place\nLaissez les âmes sœurs vous trouver";
+"plaza.share_section_title" = "Place";
+"plaza.share_toggle" = "Partager à la Place";
+"plaza.share_desc" = "Partagez votre état émotionnel publiquement";
+"plaza.tier_category_desc" = "La Place voit la catégorie et l'intensité seulement";
+"plaza.tier_emotions_desc" = "La Place voit les mots d'émotion spécifiques";
+"plaza.tier_full_desc" = "La Place voit tout, y compris les notes";

--- a/Cathier/hi.lproj/Localizable.strings
+++ b/Cathier/hi.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/it.lproj/Localizable.strings
+++ b/Cathier/it.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/ja.lproj/Localizable.strings
+++ b/Cathier/ja.lproj/Localizable.strings
@@ -260,3 +260,15 @@
 "persona.journaler.desc" = "5ステップで気づき・リフレーム・行動";
 "persona.brainTrainer.name" = "一在必成長";
 "persona.brainTrainer.desc" = "5つの質問で認知的重みを更新";
+
+/* Plaza */
+"tab.plaza" = "広場";
+"plaza.nav_title" = "広場";
+"plaza.empty" = "まだ共有されていません";
+"plaza.empty_hint" = "チェックイン後、感情を広場に共有しましょう\n同じ気持ちの人と出会えるかもしれません";
+"plaza.share_section_title" = "広場";
+"plaza.share_toggle" = "広場に共有";
+"plaza.share_desc" = "感情状態をすべてのユーザーと公開共有する";
+"plaza.tier_category_desc" = "広場には感情カテゴリと強度のみ表示";
+"plaza.tier_emotions_desc" = "広場には具体的な感情ワードを表示";
+"plaza.tier_full_desc" = "広場にはメモを含む全内容を表示";

--- a/Cathier/ko.lproj/Localizable.strings
+++ b/Cathier/ko.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "광장";
+"plaza.nav_title" = "광장";
+"plaza.empty" = "아직 공유된 게 없습니다";
+"plaza.empty_hint" = "체크인 후 감정을 광장에 공유해보세요";
+"plaza.share_section_title" = "광장";
+"plaza.share_toggle" = "광장에 공유";
+"plaza.share_desc" = "감정 상태를 모든 사용자와 공개 공유합니다";
+"plaza.tier_category_desc" = "광장에서 감정 카테고리와 강도만 표시";
+"plaza.tier_emotions_desc" = "광장에서 구체적인 감정 단어 표시";
+"plaza.tier_full_desc" = "메모 포함 모든 내용 표시";

--- a/Cathier/pt.lproj/Localizable.strings
+++ b/Cathier/pt.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Praça";
+"plaza.nav_title" = "Praça";
+"plaza.empty" = "Nada compartilhado ainda";
+"plaza.empty_hint" = "Após o check-in, compartilhe suas emoções na Praça";
+"plaza.share_section_title" = "Praça";
+"plaza.share_toggle" = "Compartilhar na Praça";
+"plaza.share_desc" = "Compartilhe seu estado emocional com todos os usuários";
+"plaza.tier_category_desc" = "Praça vê apenas categoria e intensidade";
+"plaza.tier_emotions_desc" = "Praça vê palavras de emoção específicas";
+"plaza.tier_full_desc" = "Praça vê tudo, incluindo notas";

--- a/Cathier/ru.lproj/Localizable.strings
+++ b/Cathier/ru.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Площадь";
+"plaza.nav_title" = "Площадь";
+"plaza.empty" = "Ничего не опубликовано";
+"plaza.empty_hint" = "После отметки поделитесь эмоциями на Площади";
+"plaza.share_section_title" = "Площадь";
+"plaza.share_toggle" = "Поделиться на Площади";
+"plaza.share_desc" = "Публично поделитесь своим эмоциональным состоянием";
+"plaza.tier_category_desc" = "Площадь видит только категорию и интенсивность";
+"plaza.tier_emotions_desc" = "Площадь видит конкретные эмоции";
+"plaza.tier_full_desc" = "Площадь видит всё, включая заметки";

--- a/Cathier/th.lproj/Localizable.strings
+++ b/Cathier/th.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/tr.lproj/Localizable.strings
+++ b/Cathier/tr.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Plaza";
+"plaza.nav_title" = "Plaza";
+"plaza.empty" = "Nothing shared yet";
+"plaza.empty_hint" = "After checking in, share your emotions to the Plaza";
+"plaza.share_section_title" = "Plaza";
+"plaza.share_toggle" = "Share to Plaza";
+"plaza.share_desc" = "Share your emotional state publicly with all Plaza users";
+"plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
+"plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
+"plaza.tier_full_desc" = "Plaza sees everything including notes";

--- a/Cathier/vi.lproj/Localizable.strings
+++ b/Cathier/vi.lproj/Localizable.strings
@@ -256,3 +256,15 @@
 "persona.coach.desc" = "Turn awareness into action";
 "persona.journaler.name" = "Journal Guide";
 "persona.journaler.desc" = "5-step method to reframe and act";
+
+/* Plaza */
+"tab.plaza" = "Quảng trường";
+"plaza.nav_title" = "Quảng trường";
+"plaza.empty" = "Chưa có gì được chia sẻ";
+"plaza.empty_hint" = "Sau khi check-in, hãy chia sẻ cảm xúc lên Quảng trường";
+"plaza.share_section_title" = "Quảng trường";
+"plaza.share_toggle" = "Chia sẻ lên Quảng trường";
+"plaza.share_desc" = "Chia sẻ công khai trạng thái cảm xúc với mọi người";
+"plaza.tier_category_desc" = "Quảng trường chỉ thấy danh mục và cường độ";
+"plaza.tier_emotions_desc" = "Quảng trường thấy từ cảm xúc cụ thể";
+"plaza.tier_full_desc" = "Quảng trường thấy tất cả, kể cả ghi chú";

--- a/Cathier/zh.lproj/Localizable.strings
+++ b/Cathier/zh.lproj/Localizable.strings
@@ -260,3 +260,15 @@
 "persona.journaler.desc" = "五步法：觉察→解离→调节→重构→行动";
 "persona.brainTrainer.name" = "吃一堑长一智";
 "persona.brainTrainer.desc" = "五问法：将每一次踩坑变成大脑参数的精准更新";
+
+/* Plaza */
+"tab.plaza" = "广场";
+"plaza.nav_title" = "广场";
+"plaza.empty" = "广场还没有分享";
+"plaza.empty_hint" = "完成打卡后，将你的情绪分享到广场\n让有缘人看见你此刻的感受";
+"plaza.share_section_title" = "广场";
+"plaza.share_toggle" = "分享到广场";
+"plaza.share_desc" = "向所有用户公开分享你此刻的情绪感受";
+"plaza.tier_category_desc" = "广场只看到情绪大类和强度";
+"plaza.tier_emotions_desc" = "广场看到具体情绪词";
+"plaza.tier_full_desc" = "广场看到全部内容含笔记";


### PR DESCRIPTION
Adds a new Plaza tab where users can share check-ins publicly with all Cathier users, letting kindred spirits discover shared emotional states.

Key changes:
- PlazaPost model: CloudKit record type storing denormalized display info (avatarEmoji, displayName) to avoid N+1 profile fetches in the feed
- PlazaViewModel: loads and manages the public plaza feed
- PlazaView: 5th tab (person.3.fill icon) with same auth states as FriendFeedView (loading / unavailable / needsProfile / feed)
- PlazaPostCard: emotion-category-tinted cards showing avatar, emotions, body parts, intensity, and optional AI snippet
- AIFeedbackView: new "广场" section below friend sharing — independent toggle + privacy tier picker (category / emotions / full, default: emotions)
- CheckIn model: adds isPlazaShared: Bool = false field (SwiftData handles new default-value fields without migration)
- CloudKitService: savePlazaPost / deletePlazaPost / fetchPlazaPosts
- Localization: full strings in zh/en/ja + 12 other languages

CloudKit schema note: PlazaPost record type needs a Sortable index on `date` in CloudKit Dashboard for the sort descriptor to work.