### PR TITLE
fix: propagate mood theme color to all UI controls across 24 view files

### DIFF
--- a/Cathier/Views/AboutView.swift
+++ b/Cathier/Views/AboutView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AboutView: View {
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     /// Public TestFlight join link. Generate it in App Store Connect →
     /// TestFlight → External Testing group → "Enable Public Link", then
@@ -28,7 +29,7 @@ struct AboutView: View {
                 VStack(spacing: 12) {
                     Image(systemName: "heart.text.clipboard")
                         .font(.system(size: 52))
-                        .foregroundStyle(.cathierAccent)
+                        .foregroundStyle(themeManager.accentColor)
                     Text("Cathier")
                         .font(.title2)
                         .fontWeight(.semibold)
@@ -85,7 +86,7 @@ struct AboutView: View {
                         HStack(spacing: 12) {
                             Image(systemName: "airplane.circle.fill")
                                 .font(.title3)
-                                .foregroundStyle(.cathierAccent)
+                                .foregroundStyle(themeManager.accentColor)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(lm.aboutTestFlightTitle)
                                     .foregroundStyle(.primary)

--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -6,6 +6,7 @@ struct AIFeedbackView: View {
     @Environment(FriendViewModel.self) private var friendVM
     @Environment(\.modelContext) private var modelContext
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     let onDismiss: () -> Void
 
     // Persist last chosen tier; "none" = don't share, defaults to "full"
@@ -64,7 +65,7 @@ struct AIFeedbackView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
-                .background(Color.cathierAccent)
+                .background(themeManager.accentColor)
                 .clipShape(Capsule())
                 .padding(.top, 8)
             }
@@ -130,7 +131,7 @@ struct AIFeedbackView: View {
             HStack(spacing: 6) {
                 Image(systemName: "person.2.fill")
                     .font(.caption)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                 Text(lm.aiShareTitle)
                     .font(.subheadline)
                     .fontWeight(.medium)
@@ -182,7 +183,7 @@ struct AIFeedbackView: View {
         return Button(action: { selectedTier = tier }) {
             HStack(spacing: 12) {
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                    .foregroundColor(isSelected ? .cathierAccent : .secondary)
+                    .foregroundColor(isSelected ? themeManager.accentColor : .secondary)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(label)
                         .font(.subheadline)
@@ -213,7 +214,7 @@ struct AIFeedbackView: View {
         Toggle(isOn: $shareAIFeedback) {
             HStack(spacing: 12) {
                 Image(systemName: "sparkles")
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                     .frame(width: 16)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(lm.aiShareAIFeedbackToggle)
@@ -225,7 +226,7 @@ struct AIFeedbackView: View {
                 }
             }
         }
-        .tint(.cathierAccent)
+        .tint(themeManager.accentColor)
     }
 
     // MARK: - Plaza section
@@ -415,7 +416,7 @@ struct AIFeedbackView: View {
                 .frame(width: 16)
             FlowLayout(spacing: 6) {
                 ForEach(viewModel.allEmotions, id: \.self) { emotion in
-                    let color = EmotionData.category(for: emotion)?.color ?? .cathierAccent
+                    let color = EmotionData.category(for: emotion)?.color ?? themeManager.accentColor
                     Text(lm.display(emotion))
                         .font(.caption)
                         .fontWeight(.medium)
@@ -470,8 +471,8 @@ struct AIFeedbackView: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .background(Color.cathierAccent.opacity(0.1))
-            .foregroundColor(.cathierAccent)
+            .background(themeManager.accentColor.opacity(0.1))
+            .foregroundColor(themeManager.accentColor)
             .clipShape(Capsule())
         }
     }
@@ -490,7 +491,7 @@ struct AIFeedbackView: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 6) {
                 Image(systemName: "sparkles")
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                 Text(lm.aiCompanion)
                     .font(.subheadline)
                     .fontWeight(.semibold)
@@ -528,10 +529,10 @@ struct AIFeedbackView: View {
             }
         }
         .padding(16)
-        .background(Color.cathierAccentLight)
+        .background(themeManager.accentColor.opacity(0.12))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.cathierAccent.opacity(0.2), lineWidth: 1)
+                .stroke(themeManager.accentColor.opacity(0.2), lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .animation(.easeInOut, value: viewModel.isLoadingAI)
@@ -540,7 +541,7 @@ struct AIFeedbackView: View {
     private var loadingView: some View {
         HStack(spacing: 12) {
             ProgressView()
-                .tint(.cathierAccent)
+                .tint(themeManager.accentColor)
             Text(lm.aiLoading)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
@@ -558,7 +559,7 @@ struct AIFeedbackView: View {
             }) {
                 Text(lm.aiRetry)
                     .font(.subheadline)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
             }
         }
     }
@@ -569,12 +570,13 @@ struct AIFeedbackView: View {
 struct StructuredFeedbackView: View {
     let feedback: StructuredFeedback
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            feedbackRow(icon: "waveform", titleKey: "summary", content: feedback.summary, color: .cathierAccent)
+            feedbackRow(icon: "waveform", titleKey: "summary", content: feedback.summary, color: themeManager.accentColor)
             Divider().padding(.leading, 26)
-            feedbackRow(icon: "sparkles", titleKey: "insight", content: feedback.insight, color: .cathierAccent)
+            feedbackRow(icon: "sparkles", titleKey: "insight", content: feedback.insight, color: themeManager.accentColor)
             Divider().padding(.leading, 26)
             feedbackRow(icon: "figure.mind.and.body", titleKey: "connection", content: feedback.connection, color: .cathierSage)
             Divider().padding(.leading, 26)
@@ -656,7 +658,7 @@ struct IntensityBadge: View {
     private var intensityColor: Color {
         switch intensity {
         case ..<4: return .yellow
-        case ..<7: return .cathierAccent
+        case ..<7: return .orange
         default:   return .red
         }
     }

--- a/Cathier/Views/CheckIn/BodyScanView.swift
+++ b/Cathier/Views/CheckIn/BodyScanView.swift
@@ -11,6 +11,7 @@ struct BodyScanView: View {
     @Environment(CheckInViewModel.self) private var viewModel
     @Environment(ConfigService.self) private var config
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     @State private var sheetItem: SheetItem?
 
@@ -105,7 +106,7 @@ struct BodyScanView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
-                        .background(viewModel.canProceedFromBodyScan ? Color.cathierAccent : Color(.systemGray3))
+                        .background(viewModel.canProceedFromBodyScan ? themeManager.accentColor : Color(.systemGray3))
                         .clipShape(Capsule())
                 }
                 .disabled(!viewModel.canProceedFromBodyScan)

--- a/Cathier/Views/CheckIn/BrainTrainerChatView.swift
+++ b/Cathier/Views/CheckIn/BrainTrainerChatView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct BrainTrainerChatView: View {
     @Environment(CheckInViewModel.self) private var viewModel
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     let onSave: () -> Void
 
     @State private var inputText = ""
@@ -28,16 +29,16 @@ struct BrainTrainerChatView: View {
                 VStack(alignment: .leading, spacing: 16) {
                     HStack(spacing: 6) {
                         Image(systemName: "checkmark.seal.fill")
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                         Text("复盘完成")
                             .font(.subheadline)
                             .fontWeight(.semibold)
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                     }
 
                     if viewModel.isGeneratingSummary {
                         HStack(spacing: 10) {
-                            ProgressView().tint(.cathierAccent)
+                            ProgressView().tint(themeManager.accentColor)
                             Text("正在生成总结…")
                                 .font(.subheadline)
                                 .foregroundColor(.secondary)
@@ -56,11 +57,11 @@ struct BrainTrainerChatView: View {
                 }
                 .padding(16)
             }
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColorLight)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Color.cathierAccent.opacity(0.2), lineWidth: 1)
+                    .stroke(themeManager.accentColor.opacity(0.2), lineWidth: 1)
             )
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
@@ -150,7 +151,7 @@ struct BrainTrainerChatView: View {
             .foregroundColor(.primary)
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColorLight)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .frame(maxWidth: .infinity, alignment: .trailing)
     }
@@ -158,7 +159,7 @@ struct BrainTrainerChatView: View {
     private var loadingBubble: some View {
         HStack(spacing: 8) {
             ProgressView()
-                .tint(.cathierAccent)
+                .tint(themeManager.accentColor)
                 .scaleEffect(0.8)
             Text(lm.aiLoading)
                 .font(.subheadline)
@@ -183,7 +184,7 @@ struct BrainTrainerChatView: View {
                 viewModel.startBrainTrainerSession()
             }
             .font(.caption)
-            .foregroundColor(.cathierAccent)
+            .foregroundColor(themeManager.accentColor)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
@@ -230,7 +231,7 @@ struct BrainTrainerChatView: View {
             Button(action: submitInput) {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.title2)
-                    .foregroundColor(canSend ? .cathierAccent : .secondary)
+                    .foregroundColor(canSend ? themeManager.accentColor : .secondary)
             }
             .disabled(!canSend)
         }
@@ -250,7 +251,7 @@ struct BrainTrainerChatView: View {
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
-                .background(Color.cathierAccent)
+                .background(themeManager.accentColor)
                 .clipShape(Capsule())
         }
         .padding(.horizontal, 16)

--- a/Cathier/Views/CheckIn/BrainTrainerSheet.swift
+++ b/Cathier/Views/CheckIn/BrainTrainerSheet.swift
@@ -5,6 +5,7 @@ struct BrainTrainerSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var viewModel = CheckInViewModel()
     @State private var phase: Phase = .intro
     @FocusState private var triggerFocused: Bool
@@ -43,7 +44,7 @@ struct BrainTrainerSheet: View {
                     HStack(spacing: 10) {
                         Image(systemName: "gearshape.2.fill")
                             .font(.title2)
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                         Text(introHeadline)
                             .font(.cathierSerif(.title2))
                             .foregroundColor(.primary)
@@ -78,7 +79,7 @@ struct BrainTrainerSheet: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
-                        .background(canContinue ? Color.cathierAccent : Color.cathierAccent.opacity(0.4))
+                        .background(canContinue ? themeManager.accentColor : themeManager.accentColor.opacity(0.4))
                         .clipShape(Capsule())
                 }
                 .disabled(!canContinue)

--- a/Cathier/Views/CheckIn/CheckInFlowView.swift
+++ b/Cathier/Views/CheckIn/CheckInFlowView.swift
@@ -58,6 +58,7 @@ struct CheckInFlowView: View {
 private struct StepIndicatorView: View {
     let currentStep: CheckInStep
     private let steps = CheckInStep.allCases
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         HStack(spacing: 0) {
@@ -65,16 +66,16 @@ private struct StepIndicatorView: View {
                 let isCompleted = stepIndex(step) < stepIndex(currentStep)
                 let isCurrent = step == currentStep
                 Circle()
-                    .fill(isCompleted || isCurrent ? Color.cathierAccent : Color(.systemGray4))
+                    .fill(isCompleted || isCurrent ? themeManager.accentColor : Color(.systemGray4))
                     .frame(width: 10, height: 10)
                     .overlay(
                         Circle()
-                            .stroke(isCurrent ? Color.cathierAccent : Color.clear, lineWidth: 2)
+                            .stroke(isCurrent ? themeManager.accentColor : Color.clear, lineWidth: 2)
                             .frame(width: 16, height: 16)
                     )
                 if index < steps.count - 1 {
                     Rectangle()
-                        .fill(isCompleted ? Color.cathierAccent : Color(.systemGray4))
+                        .fill(isCompleted ? themeManager.accentColor : Color(.systemGray4))
                         .frame(height: 2)
                 }
             }
@@ -93,21 +94,24 @@ private struct StepIndicatorView: View {
 struct ChipView: View {
     let label: String
     let isSelected: Bool
-    var color: Color = .cathierAccent
+    var color: Color? = nil
     let action: () -> Void
 
+    @Environment(ThemeManager.self) private var themeManager
+
     var body: some View {
-        Text(label)
+        let effectiveColor = color ?? themeManager.accentColor
+        return Text(label)
             .font(.subheadline)
             .fontWeight(isSelected ? .semibold : .regular)
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
-            .background(isSelected ? color.opacity(0.15) : Color(.systemGray6))
-            .foregroundColor(isSelected ? color : .primary)
+            .background(isSelected ? effectiveColor.opacity(0.15) : Color(.systemGray6))
+            .foregroundColor(isSelected ? effectiveColor : .primary)
             .clipShape(Capsule())
             .overlay(
                 Capsule()
-                    .stroke(isSelected ? color : Color.clear, lineWidth: 1.5)
+                    .stroke(isSelected ? effectiveColor : Color.clear, lineWidth: 1.5)
             )
             .contentShape(Capsule())
             .onTapGesture {

--- a/Cathier/Views/CheckIn/EmotionLabelView.swift
+++ b/Cathier/Views/CheckIn/EmotionLabelView.swift
@@ -11,6 +11,7 @@ struct EmotionLabelView: View {
     @Environment(CheckInViewModel.self) private var viewModel
     @Environment(ConfigService.self) private var config
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var sheetEntry: IdentifiableDictionaryEntry?
 
     var body: some View {
@@ -91,7 +92,7 @@ struct EmotionLabelView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
-                        .background(viewModel.canProceedFromEmotionLabel ? Color.cathierAccent : Color(.systemGray3))
+                        .background(viewModel.canProceedFromEmotionLabel ? themeManager.accentColor : Color(.systemGray3))
                         .cornerRadius(14)
                 }
                 .disabled(!viewModel.canProceedFromEmotionLabel)
@@ -123,7 +124,7 @@ struct EmotionLabelView: View {
                 .foregroundColor(.secondary)
             FlowLayout(spacing: 8) {
                 ForEach(viewModel.allEmotions, id: \.self) { emotion in
-                    let color = EmotionData.category(for: emotion)?.color ?? .cathierAccent
+                    let color = EmotionData.category(for: emotion)?.color ?? themeManager.accentColor
                     let emoji = EmotionData.emoji(for: emotion)
                     HStack(spacing: 4) {
                         Text(emoji.isEmpty ? emotion : "\(emoji) \(emotion)")

--- a/Cathier/Views/CheckIn/MicroExerciseView.swift
+++ b/Cathier/Views/CheckIn/MicroExerciseView.swift
@@ -7,6 +7,7 @@ struct MicroExerciseView: View {
     let emotions: [String]
     @Environment(\.dismiss) private var dismiss
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var exerciseText: String = ""
     @State private var isLoading = true
     @State private var errorMessage: String?
@@ -51,7 +52,7 @@ struct MicroExerciseView: View {
         VStack(spacing: 16) {
             ProgressView()
                 .scaleEffect(1.4)
-                .tint(.cathierAccent)
+                .tint(themeManager.accentColor)
             Text(lm.exerciseLoading)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -66,7 +67,7 @@ struct MicroExerciseView: View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 36))
-                .foregroundColor(.cathierAccent)
+                .foregroundColor(themeManager.accentColor)
             Text(message)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
@@ -74,7 +75,7 @@ struct MicroExerciseView: View {
             Button(lm.exerciseRetry) {
                 Task { await loadExercise() }
             }
-            .foregroundColor(.cathierAccent)
+            .foregroundColor(themeManager.accentColor)
         }
         .padding(.vertical, 40)
     }
@@ -88,7 +89,7 @@ struct MicroExerciseView: View {
                 .font(.cathierSerif(.body))
                 .lineSpacing(5)
                 .padding(16)
-                .background(Color.cathierAccentLight)
+                .background(themeManager.accentColorLight)
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
 
             // Timer
@@ -108,7 +109,7 @@ struct MicroExerciseView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(Color.cathierAccent)
+                    .background(themeManager.accentColor)
                     .foregroundStyle(.white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
                 }
@@ -118,7 +119,7 @@ struct MicroExerciseView: View {
                     ZStack {
                         // Background track
                         Circle()
-                            .stroke(Color.cathierAccent.opacity(0.2), lineWidth: 16)
+                            .stroke(themeManager.accentColor.opacity(0.2), lineWidth: 16)
 
                         // Progress ring
                         Circle()
@@ -126,8 +127,8 @@ struct MicroExerciseView: View {
                             .stroke(
                                 AngularGradient(
                                     gradient: Gradient(colors: [
-                                        Color.cathierAccent.opacity(0.6),
-                                        Color.cathierAccent
+                                        themeManager.accentColor.opacity(0.6),
+                                        themeManager.accentColor
                                     ]),
                                     center: .center,
                                     startAngle: .degrees(0),
@@ -142,7 +143,7 @@ struct MicroExerciseView: View {
                         Text(formattedTime)
                             .font(.system(size: 48, weight: .light, design: .rounded))
                             .monospacedDigit()
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                     }
                     .frame(width: 200, height: 200)
 

--- a/Cathier/Views/Components/CheckInCard.swift
+++ b/Cathier/Views/Components/CheckInCard.swift
@@ -4,6 +4,7 @@ struct CheckInCard: View {
     let checkIn: CheckIn
     @State private var showDetail = false
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         Button(action: { showDetail = true }) {
@@ -16,7 +17,7 @@ struct CheckInCard: View {
                     if checkIn.shareLevel != nil {
                         Image(systemName: "person.2.fill")
                             .font(.caption2)
-                            .foregroundColor(.cathierAccent.opacity(0.8))
+                            .foregroundColor(themeManager.accentColor.opacity(0.8))
                     }
                     Spacer()
                     IntensityBadge(intensity: checkIn.intensity, label: lm.aiIntensityBadge(checkIn.intensity))
@@ -31,7 +32,7 @@ struct CheckInCard: View {
                 if !checkIn.emotions.isEmpty {
                     FlowLayout(spacing: 6) {
                         ForEach(checkIn.emotions, id: \.self) { emotion in
-                            let color = EmotionData.category(for: emotion)?.color ?? .cathierAccent
+                            let color = EmotionData.category(for: emotion)?.color ?? themeManager.accentColor
                             let emoji = EmotionData.emoji(for: emotion)
                             Text(emoji.isEmpty ? emotion : "\(emoji) \(emotion)")
                                 .font(.caption)
@@ -51,7 +52,7 @@ struct CheckInCard: View {
                     HStack(alignment: .top, spacing: 6) {
                         Image(systemName: "sparkles")
                             .font(.caption2)
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                             .padding(.top, 2)
                         Text(StructuredFeedback.parse(checkIn.aiFeedback)?.previewText ?? checkIn.aiFeedback)
                             .font(.subheadline)
@@ -99,7 +100,7 @@ struct CheckInCard: View {
                     Text(partName)
                         .font(.subheadline)
                         .fontWeight(.medium)
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                     if !sensations.isEmpty {
                         Text(sensations.map { lm.display($0) }.joined(separator: " · "))
                             .font(.subheadline)

--- a/Cathier/Views/Components/CheckInDetailView.swift
+++ b/Cathier/Views/Components/CheckInDetailView.swift
@@ -6,6 +6,7 @@ struct CheckInDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(LanguageManager.self) private var lm
     @Environment(FriendViewModel.self) private var friendVM
+    @Environment(ThemeManager.self) private var themeManager
     @Query(sort: \CheckIn.date, order: .reverse) private var allCheckIns: [CheckIn]
     @State private var isBusy = false
     @State private var shareError: String?
@@ -50,14 +51,14 @@ struct CheckInDetailView: View {
                                 if !checkIn.bodyParts.isEmpty {
                                     FlowLayout(spacing: 8) {
                                         ForEach(checkIn.bodyParts, id: \.self) { part in
-                                            chip(lm.display(part), color: .cathierAccent)
+                                            chip(lm.display(part), color: themeManager.accentColor)
                                         }
                                     }
                                 }
                                 if !parsed.global.isEmpty {
                                     FlowLayout(spacing: 8) {
                                         ForEach(parsed.global, id: \.self) { s in
-                                            chip(lm.display(s), color: .cathierAccent)
+                                            chip(lm.display(s), color: themeManager.accentColor)
                                         }
                                     }
                                 }
@@ -68,10 +69,10 @@ struct CheckInDetailView: View {
                                         Text(lm.display(entry.part))
                                             .font(.caption)
                                             .fontWeight(.medium)
-                                            .foregroundColor(.cathierAccent)
+                                            .foregroundColor(themeManager.accentColor)
                                         FlowLayout(spacing: 6) {
                                             ForEach(entry.sensations, id: \.self) { s in
-                                                chip(lm.display(s), color: .cathierAccent)
+                                                chip(lm.display(s), color: themeManager.accentColor)
                                             }
                                         }
                                     }
@@ -79,7 +80,7 @@ struct CheckInDetailView: View {
                                 if !parsed.global.isEmpty {
                                     FlowLayout(spacing: 8) {
                                         ForEach(parsed.global, id: \.self) { s in
-                                            chip(lm.display(s), color: .cathierAccent)
+                                            chip(lm.display(s), color: themeManager.accentColor)
                                         }
                                     }
                                 }
@@ -96,7 +97,7 @@ struct CheckInDetailView: View {
                                 .foregroundColor(.secondary)
                             FlowLayout(spacing: 8) {
                                 ForEach(checkIn.emotions, id: \.self) { emotion in
-                                    let color = EmotionData.category(for: emotion)?.color ?? .cathierAccent
+                                    let color = EmotionData.category(for: emotion)?.color ?? themeManager.accentColor
                                     let emoji = EmotionData.emoji(for: emotion)
                                     chip(emoji.isEmpty ? emotion : "\(emoji) \(emotion)",
                                          color: color,
@@ -127,7 +128,7 @@ struct CheckInDetailView: View {
                                 Label(lm.aiCompanion, systemImage: "sparkles")
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
-                                    .foregroundColor(.cathierAccent)
+                                    .foregroundColor(themeManager.accentColor)
                                 Spacer()
                                 ShareLink(item: aiFeedbackShareText) {
                                     Image(systemName: "square.and.arrow.up")
@@ -158,7 +159,7 @@ struct CheckInDetailView: View {
                         }
                         .overlay(
                             RoundedRectangle(cornerRadius: 14)
-                                .stroke(Color.cathierAccent.opacity(0.25), lineWidth: 1)
+                                .stroke(themeManager.accentColor.opacity(0.25), lineWidth: 1)
                         )
                     }
 
@@ -210,7 +211,7 @@ struct CheckInDetailView: View {
             if isShared, let tier = currentTier {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                     Text(tier.displayName)
                         .font(.subheadline)
                     Text("·")
@@ -289,7 +290,7 @@ struct CheckInDetailView: View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: 14)
-                .stroke(isShared ? Color.cathierAccent.opacity(0.3) : Color.clear, lineWidth: 1)
+                .stroke(isShared ? themeManager.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
         )
     }
 
@@ -439,6 +440,6 @@ struct CheckInDetailView: View {
         case .ja: label = diff > 0 ? "↑ 平均 \(avgText) より高" : "↓ 平均 \(avgText) より低"
         default:  label = diff > 0 ? "↑ Above avg \(avgText)" : "↓ Below avg \(avgText)"
         }
-        return IntensityContext(label: label, color: diff > 0 ? .cathierAccent : .cathierSage)
+        return IntensityContext(label: label, color: diff > 0 ? themeManager.accentColor : .cathierSage)
     }
 }

--- a/Cathier/Views/Components/DailyJournalCard.swift
+++ b/Cathier/Views/Components/DailyJournalCard.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DailyJournalCard: View {
     let journal: DailyJournal
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     var onEdit: (() -> Void)? = nil
 
     var body: some View {
@@ -26,11 +27,11 @@ struct DailyJournalCard: View {
                     systemImage: journal.isShared ? "person.2.fill" : "lock.fill"
                 )
                 .font(.caption)
-                .foregroundColor(journal.isShared ? .cathierAccent : .secondary)
+                .foregroundColor(journal.isShared ? themeManager.accentColor : .secondary)
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
                 .background(
-                    (journal.isShared ? Color.cathierAccent : Color.secondary)
+                    (journal.isShared ? themeManager.accentColor : Color.secondary)
                         .opacity(0.1)
                 )
                 .clipShape(Capsule())
@@ -39,7 +40,7 @@ struct DailyJournalCard: View {
                     Button(action: edit) {
                         Image(systemName: "pencil.circle.fill")
                             .font(.title3)
-                            .foregroundColor(.cathierAccent.opacity(0.8))
+                            .foregroundColor(themeManager.accentColor.opacity(0.8))
                     }
                     .buttonStyle(.plain)
                 }

--- a/Cathier/Views/Components/EmotionPopoverView.swift
+++ b/Cathier/Views/Components/EmotionPopoverView.swift
@@ -4,6 +4,7 @@ struct EmotionPopoverView: View {
     let emotion: Emotion
     let categoryColor: Color
     var onSimilarTap: ((String) -> Void)?
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -33,7 +34,7 @@ struct EmotionPopoverView: View {
                             }
                             .font(.caption)
                             .fontWeight(.medium)
-                            .foregroundStyle(Color.cathierAccent)
+                            .foregroundStyle(themeManager.accentColor)
 
                             if let diff = emotion.differs?[name] {
                                 Text(diff)

--- a/Cathier/Views/EmotionExplorerView.swift
+++ b/Cathier/Views/EmotionExplorerView.swift
@@ -6,6 +6,7 @@ import SwiftData
 struct EmotionExplorerView: View {
     @Environment(ConfigService.self) private var config
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @Query private var allCheckIns: [CheckIn]
     @State private var selectedTab = 0
     @State private var selectedItem: SelectedItem?
@@ -59,7 +60,7 @@ struct EmotionExplorerView: View {
             HStack(spacing: 8) {
                 Image(systemName: "book.fill")
                     .font(.caption)
-                    .foregroundStyle(Color.cathierAccent)
+                    .foregroundStyle(themeManager.accentColor)
                 Text(vocabBannerTitle)
                     .font(.caption)
                     .foregroundStyle(Color.secondary)
@@ -68,7 +69,7 @@ struct EmotionExplorerView: View {
                     Text("\(used)")
                         .font(.system(.caption, design: .monospaced))
                         .fontWeight(.bold)
-                        .foregroundStyle(Color.cathierAccent)
+                        .foregroundStyle(themeManager.accentColor)
                     Text("/ \(total)")
                         .font(.system(.caption2, design: .monospaced))
                         .foregroundStyle(Color.secondary)
@@ -76,7 +77,7 @@ struct EmotionExplorerView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColorLight)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             .padding(.horizontal, 20)
         }
@@ -98,7 +99,7 @@ struct EmotionExplorerView: View {
                 vocabBanner
                 ForEach(DictionaryService.emotionsByCategory, id: \.category) { group in
                     let cat = config.categories.first { $0.nameZh == group.category }
-                    let color = cat?.color ?? .cathierAccent
+                    let color = cat?.color ?? themeManager.accentColor
 
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(spacing: 8) {
@@ -196,7 +197,7 @@ struct EmotionExplorerView: View {
     }
 
     private func categoryColor(for name: String) -> Color {
-        config.categories.first { $0.nameZh == name }?.color ?? .cathierAccent
+        config.categories.first { $0.nameZh == name }?.color ?? themeManager.accentColor
     }
 }
 
@@ -358,6 +359,7 @@ struct EmotionDictionarySheet: View {
 struct SensationDictionarySheet: View {
     let entry: DictionaryEntry
     @Environment(\.dismiss) private var dismiss
+    @Environment(ThemeManager.self) private var themeManager
     private let color: Color = .cathierSage
 
     var body: some View {
@@ -386,7 +388,7 @@ struct SensationDictionarySheet: View {
                             SheetSection(icon: "figure.stand", title: "常见部位", color: color) { chipList(locs, color: color) }
                         }
                         if let emo = entry.relatedEmotions, !emo.isEmpty {
-                            SheetSection(icon: "heart", title: "常伴随情绪", color: color) { chipList(emo, color: .cathierAccent) }
+                            SheetSection(icon: "heart", title: "常伴随情绪", color: color) { chipList(emo, color: themeManager.accentColor) }
                         }
                         if let v = entry.signalMeaning, !v.isEmpty { SheetSection(icon: "exclamationmark.bubble", title: "身体在说什么", color: color) { serifText(v) } }
                         if let v = entry.selfCare, !v.isEmpty { SheetSection(icon: "leaf", title: "可以做什么", color: color) { serifText(v) } }
@@ -436,7 +438,8 @@ struct SensationDictionarySheet: View {
 struct BodyPartDictionarySheet: View {
     let entry: DictionaryEntry
     @Environment(\.dismiss) private var dismiss
-    private let color: Color = .cathierAccent
+    @Environment(ThemeManager.self) private var themeManager
+    private var color: Color { themeManager.accentColor }
 
     var body: some View {
         NavigationStack {

--- a/Cathier/Views/FeedbackView.swift
+++ b/Cathier/Views/FeedbackView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FeedbackView: View {
     @Environment(LanguageManager.self) private var lm
     @Environment(\.dismiss) private var dismiss
+    @Environment(ThemeManager.self) private var themeManager
 
     @State private var title = ""
     @State private var bodyText = ""
@@ -33,10 +34,10 @@ struct FeedbackView: View {
                 if let url = submittedURL {
                     Section {
                         Link(lm.feedbackViewIssue, destination: url)
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                     } header: {
                         Text(lm.feedbackSuccess)
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                     }
                 }
 

--- a/Cathier/Views/Friend/FriendFeedView.swift
+++ b/Cathier/Views/Friend/FriendFeedView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct FriendFeedView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         NavigationStack {
@@ -47,7 +48,7 @@ struct FriendFeedView: View {
             }) {
                 Text(lm.friendRetry)
                     .font(.subheadline)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -60,6 +61,7 @@ private struct FriendHomeView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(ThemeManager.self) private var themeManager
     @Query(filter: #Predicate<DailyJournal> { $0.isShared }, sort: \DailyJournal.date, order: .reverse)
     private var sharedJournals: [DailyJournal]
 
@@ -180,13 +182,13 @@ private struct FriendHomeView: View {
                     VStack(spacing: 4) {
                         Image(systemName: "person.badge.plus")
                             .font(.system(size: 22))
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                             .frame(width: 52, height: 52)
-                            .background(Color.cathierAccent.opacity(0.12))
+                            .background(themeManager.accentColor.opacity(0.12))
                             .clipShape(Circle())
                         Text(lm.manageAddFriend)
                             .font(.caption2)
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                             .lineLimit(1)
                             .frame(width: 52)
                     }
@@ -235,7 +237,7 @@ private struct FriendHomeView: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 28)
                     .padding(.vertical, 12)
-                    .background(Color.cathierAccent)
+                    .background(themeManager.accentColor)
                     .clipShape(Capsule())
             }
         }
@@ -256,7 +258,7 @@ private struct FriendHomeView: View {
                     .foregroundColor(.white)
                     .padding(.horizontal, 28)
                     .padding(.vertical, 12)
-                    .background(Color.cathierAccent)
+                    .background(themeManager.accentColor)
                     .clipShape(Capsule())
             }
         }
@@ -289,6 +291,7 @@ struct FriendCheckInCard: View {
     let owner: UserProfile?
     @Environment(LanguageManager.self) private var lm
     @Environment(FriendViewModel.self) private var vm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var showFullAI = false
 
     var body: some View {
@@ -418,7 +421,7 @@ struct FriendCheckInCard: View {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "sparkles")
                     .font(.caption2)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                     .padding(.top, 3)
                 VStack(alignment: .leading, spacing: 4) {
                     Text(StructuredFeedback.parse(item.aiFeedback)?.previewText ?? item.aiFeedback.firstSentence)
@@ -429,14 +432,14 @@ struct FriendCheckInCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(lm.aiReadMore)
                         .font(.caption2)
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                 }
             }
             .padding(10)
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColorLight)
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.cathierAccent.opacity(0.15), lineWidth: 1)
+                    .stroke(themeManager.accentColor.opacity(0.15), lineWidth: 1)
             )
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
@@ -465,7 +468,7 @@ struct FriendCheckInCard: View {
                         }
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
-                        .background(isMine ? Color.cathierAccent : Color(.systemGray5))
+                        .background(isMine ? themeManager.accentColor : Color(.systemGray5))
                         .clipShape(Capsule())
                     }
                     .buttonStyle(.plain)
@@ -482,6 +485,7 @@ struct SharedJournalFeedRow: View {
     let journal: DailyJournal
     let profile: UserProfile?
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -546,6 +550,7 @@ struct FriendAIDetailView: View {
     let owner: UserProfile?
     @Environment(LanguageManager.self) private var lm
     @Environment(\.dismiss) private var dismiss
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         NavigationStack {
@@ -576,7 +581,7 @@ struct FriendAIDetailView: View {
                             HStack(alignment: .top, spacing: 8) {
                                 Image(systemName: "sparkles")
                                     .font(.subheadline)
-                                    .foregroundColor(.cathierAccent)
+                                    .foregroundColor(themeManager.accentColor)
                                     .padding(.top, 2)
                                 Text(item.aiFeedback)
                                     .font(.cathierSerif(.body))
@@ -587,10 +592,10 @@ struct FriendAIDetailView: View {
                         }
                     }
                     .padding(14)
-                    .background(Color.cathierAccentLight)
+                    .background(themeManager.accentColorLight)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(Color.cathierAccent.opacity(0.15), lineWidth: 1)
+                            .stroke(themeManager.accentColor.opacity(0.15), lineWidth: 1)
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }

--- a/Cathier/Views/Friend/FriendManageView.swift
+++ b/Cathier/Views/Friend/FriendManageView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FriendManageView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var removingFriend: UserProfile?
     @State private var showRemoveAlert = false
     @State private var showErrorAlert = false
@@ -124,7 +125,7 @@ struct FriendManageView: View {
                 .foregroundColor(.white)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(Color.cathierAccent)
+                .background(themeManager.accentColor)
                 .clipShape(Capsule())
                 .contentShape(Capsule())
                 .buttonStyle(.plain)

--- a/Cathier/Views/Friend/FriendSetupView.swift
+++ b/Cathier/Views/Friend/FriendSetupView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FriendSetupView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     @State private var displayName = ""
     @State private var avatarEmoji = "🙂"
@@ -41,11 +42,11 @@ struct FriendSetupView: View {
                                 Text(emoji)
                                     .font(.title2)
                                     .frame(width: 40, height: 40)
-                                    .background(avatarEmoji == emoji ? Color.cathierAccent.opacity(0.2) : Color(.systemGray6))
+                                    .background(avatarEmoji == emoji ? themeManager.accentColor.opacity(0.2) : Color(.systemGray6))
                                     .cornerRadius(10)
                                     .overlay(
                                         RoundedRectangle(cornerRadius: 10)
-                                            .stroke(avatarEmoji == emoji ? Color.cathierAccent : Color.clear, lineWidth: 2)
+                                            .stroke(avatarEmoji == emoji ? themeManager.accentColor : Color.clear, lineWidth: 2)
                                     )
                             }
                             .buttonStyle(.plain)
@@ -85,7 +86,7 @@ struct FriendSetupView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
-                .background(canConfirm ? Color.cathierAccent : Color(.systemGray3))
+                .background(canConfirm ? themeManager.accentColor : Color(.systemGray3))
                 .cornerRadius(14)
                 .disabled(!canConfirm || isLoading)
                 .padding(.horizontal, 20)

--- a/Cathier/Views/Friend/InviteView.swift
+++ b/Cathier/Views/Friend/InviteView.swift
@@ -5,6 +5,7 @@ struct AddFriendView: View {
     @Environment(FriendViewModel.self) private var vm
     @Environment(LanguageManager.self) private var lm
     @Environment(\.dismiss) private var dismiss
+    @Environment(ThemeManager.self) private var themeManager
 
     @State private var sendingToID: String?
     @State private var sendError: String?
@@ -83,10 +84,10 @@ struct AddFriendView: View {
         } else if vm.hasSentRequest(to: profile) {
             Text(lm.searchRequested)
                 .font(.caption)
-                .foregroundColor(.cathierAccent)
+                .foregroundColor(themeManager.accentColor)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(Color.cathierAccent.opacity(0.12))
+                .background(themeManager.accentColor.opacity(0.12))
                 .clipShape(Capsule())
         } else {
             Button { sendRequest(to: profile) } label: {
@@ -100,7 +101,7 @@ struct AddFriendView: View {
                         .foregroundColor(.white)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 6)
-                        .background(Color.cathierAccent)
+                        .background(themeManager.accentColor)
                         .clipShape(Capsule())
                         .contentShape(Capsule())
                 }

--- a/Cathier/Views/HealthInsightView.swift
+++ b/Cathier/Views/HealthInsightView.swift
@@ -10,6 +10,7 @@ struct HealthInsightView: View {
     @State private var isAnalyzing = false
     @State private var analysisError: String? = nil
     @Environment(\.dismiss) private var dismiss
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         NavigationStack {
@@ -39,7 +40,7 @@ struct HealthInsightView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(lm.checkInCancel) { dismiss() }
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                 }
             }
         }
@@ -82,11 +83,11 @@ struct HealthInsightView: View {
         VStack(spacing: 20) {
             ZStack {
                 Circle()
-                    .fill(Color.cathierAccent.opacity(0.12))
+                    .fill(themeManager.accentColor.opacity(0.12))
                     .frame(width: 72, height: 72)
                 Image(systemName: "heart.text.clipboard.fill")
                     .font(.system(size: 32))
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
             }
 
             VStack(spacing: 8) {
@@ -112,7 +113,7 @@ struct HealthInsightView: View {
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
-                    .background(Color.cathierAccent)
+                    .background(themeManager.accentColor)
                     .clipShape(RoundedRectangle(cornerRadius: 9999, style: .continuous))
             }
             .buttonStyle(.plain)
@@ -127,7 +128,7 @@ struct HealthInsightView: View {
     private var loadingView: some View {
         VStack(spacing: 12) {
             ProgressView()
-                .tint(.cathierAccent)
+                .tint(themeManager.accentColor)
             Text(lm.currentLanguage == .zh ? "正在读取健康数据…" : lm.currentLanguage == .ja ? "ヘルスデータを読み込み中…" : "Reading health data…")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
@@ -143,7 +144,7 @@ struct HealthInsightView: View {
             HStack(spacing: 12) {
                 metricCard(
                     icon: "figure.walk",
-                    color: .cathierAccent,
+                    color: themeManager.accentColor,
                     title: lm.currentLanguage == .zh ? "今日步数" : lm.currentLanguage == .ja ? "今日の歩数" : "Steps Today",
                     value: service.summary.stepsToday > 0
                         ? "\(service.summary.stepsToday.formatted())"
@@ -152,7 +153,7 @@ struct HealthInsightView: View {
                 )
                 metricCard(
                     icon: "flame.fill",
-                    color: .cathierAccent,
+                    color: themeManager.accentColor,
                     title: lm.currentLanguage == .zh ? "活动能量" : lm.currentLanguage == .ja ? "活動エネルギー" : "Active Energy",
                     value: service.summary.activeEnergyToday > 0
                         ? "\(Int(service.summary.activeEnergyToday))"
@@ -220,7 +221,7 @@ struct HealthInsightView: View {
                     x: .value("Day", item.date, unit: .day),
                     y: .value("Steps", item.steps)
                 )
-                .foregroundStyle(Color.cathierAccent.opacity(0.8))
+                .foregroundStyle(themeManager.accentColor.opacity(0.8))
                 .cornerRadius(4)
             }
             .chartXAxis {
@@ -250,18 +251,18 @@ struct HealthInsightView: View {
             // Header strip
             HStack(spacing: 8) {
                 Circle()
-                    .fill(Color.cathierAccent)
+                    .fill(themeManager.accentColor)
                     .frame(width: 6, height: 6)
                 Text("Cathier AI")
                     .font(.system(.caption2, design: .default).weight(.semibold))
                     .textCase(.uppercase)
                     .tracking(0.08 * 12)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                 Spacer()
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColorLight)
             .clipShape(UnevenRoundedRectangle(
                 cornerRadii: RectangleCornerRadii(topLeading: 12, bottomLeading: 0, bottomTrailing: 0, topTrailing: 12),
                 style: .continuous
@@ -276,7 +277,7 @@ struct HealthInsightView: View {
                 } else if isAnalyzing {
                     HStack(spacing: 10) {
                         ProgressView()
-                            .tint(.cathierAccent)
+                            .tint(themeManager.accentColor)
                             .scaleEffect(0.8)
                         Text(lm.currentLanguage == .zh ? "正在分析…" : lm.currentLanguage == .ja ? "分析中…" : "Analyzing…")
                             .font(.subheadline)
@@ -286,12 +287,12 @@ struct HealthInsightView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text(error)
                             .font(.caption)
-                            .foregroundColor(Color.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                         Button(lm.aiRetry) {
                             runAnalysis()
                         }
                         .font(.caption)
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                     }
                 } else {
                     Button {
@@ -307,7 +308,7 @@ struct HealthInsightView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
-                        .background(Color.cathierAccent)
+                        .background(themeManager.accentColor)
                         .clipShape(RoundedRectangle(cornerRadius: 9999, style: .continuous))
                     }
                     .buttonStyle(.plain)
@@ -323,7 +324,7 @@ struct HealthInsightView: View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.cathierAccent.opacity(0.3), lineWidth: 1)
+                .stroke(themeManager.accentColor.opacity(0.3), lineWidth: 1)
         )
     }
 

--- a/Cathier/Views/InsightsView.swift
+++ b/Cathier/Views/InsightsView.swift
@@ -4,6 +4,7 @@ import Charts
 
 struct InsightsView: View {
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @Query(sort: \CheckIn.date, order: .forward) private var checkIns: [CheckIn]
     @State private var vm = InsightsViewModel()
 
@@ -97,7 +98,7 @@ struct InsightsView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .background(vm.isLoading ? Color.cathierAccent.opacity(0.6) : Color.cathierAccent)
+            .background(vm.isLoading ? themeManager.accentColor.opacity(0.6) : themeManager.accentColor)
             .foregroundStyle(.white)
             .clipShape(RoundedRectangle(cornerRadius: 14))
         }
@@ -145,7 +146,7 @@ struct InsightsView: View {
                 .font(.cathierSerif(.body))
                 .lineSpacing(5)
                 .padding()
-                .background(Color.cathierAccentLight)
+                .background(themeManager.accentColorLight)
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                 .padding(.horizontal)
         }
@@ -174,7 +175,7 @@ struct InsightsView: View {
                     x: .value("Count", item.count),
                     y: .value("Emotion", item.emotion)
                 )
-                .foregroundStyle(Color.cathierAccent.gradient)
+                .foregroundStyle(themeManager.accentColor.gradient)
                 .cornerRadius(4)
             }
             .chartXAxis {
@@ -231,7 +232,7 @@ struct InsightsView: View {
                     x: .value("Day", item.label),
                     y: .value("Avg", item.avg)
                 )
-                .foregroundStyle(Color.cathierAccent.opacity(0.75).gradient)
+                .foregroundStyle(themeManager.accentColor.opacity(0.75).gradient)
                 .cornerRadius(4)
             }
             .chartYScale(domain: 0...10)
@@ -297,7 +298,7 @@ struct InsightsView: View {
                     x: .value("Time", item.label),
                     y: .value("Avg", item.avg)
                 )
-                .foregroundStyle(Color.cathierAccent.opacity(0.6).gradient)
+                .foregroundStyle(themeManager.accentColor.opacity(0.6).gradient)
                 .cornerRadius(4)
             }
             .chartYScale(domain: 0...10)
@@ -325,14 +326,14 @@ struct InsightsView: View {
                     y: .value("Intensity", c.intensity)
                 )
                 .interpolationMethod(.catmullRom)
-                .foregroundStyle(Color.cathierAccent.gradient)
+                .foregroundStyle(themeManager.accentColor.gradient)
 
                 AreaMark(
                     x: .value("Date", c.date),
                     y: .value("Intensity", c.intensity)
                 )
                 .interpolationMethod(.catmullRom)
-                .foregroundStyle(Color.cathierAccent.opacity(0.15).gradient)
+                .foregroundStyle(themeManager.accentColor.opacity(0.15).gradient)
             }
             .chartYScale(domain: 0...10)
             .chartXAxis {
@@ -352,10 +353,10 @@ struct InsightsView: View {
     private func errorBanner(_ message: String) -> some View {
         Label(message, systemImage: "exclamationmark.triangle.fill")
             .font(.subheadline)
-            .foregroundStyle(.cathierAccent)
+            .foregroundStyle(themeManager.accentColor)
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color.cathierAccent.opacity(0.1))
+            .background(themeManager.accentColor.opacity(0.1))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .padding(.horizontal)
     }
@@ -405,6 +406,7 @@ private struct FocusChip: View {
     let action: () -> Void
 
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var label: String {
         switch mode {
@@ -422,7 +424,7 @@ private struct FocusChip: View {
                 .fontWeight(isSelected ? .semibold : .regular)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
-                .background(isSelected ? Color.cathierAccent : Color(.tertiarySystemBackground))
+                .background(isSelected ? themeManager.accentColor : Color(.tertiarySystemBackground))
                 .foregroundStyle(isSelected ? .white : .primary)
                 .clipShape(Capsule())
                 .overlay(

--- a/Cathier/Views/JournalView.swift
+++ b/Cathier/Views/JournalView.swift
@@ -10,6 +10,7 @@ struct JournalView: View {
     @State private var searchText = ""
     @State private var pendingDelete: CheckIn? = nil
     @State private var deleteTask: Task<Void, Never>? = nil
+    @Environment(ThemeManager.self) private var themeManager
 
     private var filteredCheckIns: [CheckIn] {
         let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
@@ -82,7 +83,7 @@ struct JournalView: View {
                         showInsights = true
                     } label: {
                         Image(systemName: "chart.line.uptrend.xyaxis")
-                            .foregroundStyle(.cathierAccent)
+                            .foregroundStyle(themeManager.accentColor)
                     }
                     .accessibilityLabel(lm.insightsNavTitle)
                 }
@@ -220,7 +221,7 @@ struct JournalView: View {
                 Text(undoActionLabel)
                     .font(.subheadline)
                     .fontWeight(.semibold)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
             }
             .buttonStyle(.plain)
         }

--- a/Cathier/Views/Plaza/PlazaView.swift
+++ b/Cathier/Views/Plaza/PlazaView.swift
@@ -5,6 +5,7 @@ struct PlazaView: View {
     @Environment(FriendViewModel.self) private var friendVM
     @Environment(PlazaViewModel.self) private var plazaVM
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         NavigationStack {
@@ -45,7 +46,7 @@ struct PlazaView: View {
             } label: {
                 Text(lm.friendRetry)
                     .font(.subheadline)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -58,6 +59,7 @@ private struct PlazaFeedView: View {
     @Environment(PlazaViewModel.self) private var plazaVM
     @Environment(LanguageManager.self) private var lm
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         Group {
@@ -111,6 +113,7 @@ private struct PlazaFeedView: View {
 private struct PlazaPostCard: View {
     let post: PlazaPost
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var showFullAI = false
 
     var body: some View {
@@ -245,7 +248,7 @@ private struct PlazaPostCard: View {
             HStack(alignment: .top, spacing: 8) {
                 Image(systemName: "sparkles")
                     .font(.caption2)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                     .padding(.top, 3)
                 VStack(alignment: .leading, spacing: 4) {
                     Text(StructuredFeedback.parse(post.aiFeedback)?.previewText ?? post.aiFeedback.plazaFirstSentence)
@@ -256,14 +259,14 @@ private struct PlazaPostCard: View {
                         .fixedSize(horizontal: false, vertical: true)
                     Text(lm.aiReadMore)
                         .font(.caption2)
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                 }
             }
             .padding(10)
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColorLight)
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.cathierAccent.opacity(0.15), lineWidth: 1)
+                    .stroke(themeManager.accentColor.opacity(0.15), lineWidth: 1)
             )
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
@@ -277,6 +280,7 @@ struct PlazaAIDetailView: View {
     let post: PlazaPost
     @Environment(LanguageManager.self) private var lm
     @Environment(\.dismiss) private var dismiss
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         NavigationStack {
@@ -305,7 +309,7 @@ struct PlazaAIDetailView: View {
                             HStack(alignment: .top, spacing: 8) {
                                 Image(systemName: "sparkles")
                                     .font(.subheadline)
-                                    .foregroundColor(.cathierAccent)
+                                    .foregroundColor(themeManager.accentColor)
                                     .padding(.top, 2)
                                 Text(post.aiFeedback)
                                     .font(.cathierSerif(.body))
@@ -316,10 +320,10 @@ struct PlazaAIDetailView: View {
                         }
                     }
                     .padding(14)
-                    .background(Color.cathierAccentLight)
+                    .background(themeManager.accentColorLight)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
-                            .stroke(Color.cathierAccent.opacity(0.15), lineWidth: 1)
+                            .stroke(themeManager.accentColor.opacity(0.15), lineWidth: 1)
                     )
                     .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                 }

--- a/Cathier/Views/SettingsView.swift
+++ b/Cathier/Views/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @State private var isAuthorized = false
     @State private var showFeedback = false
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @FocusState private var isContextBriefFocused: Bool
 
     var body: some View {
@@ -30,7 +31,7 @@ struct SettingsView: View {
                 // MARK: - Notification Settings
                 Section {
                     Toggle(lm.settingsEnableReminder, isOn: $notificationsEnabled)
-                        .tint(.cathierAccent)
+                        .tint(themeManager.accentColor)
                         .onChange(of: notificationsEnabled) { _, enabled in
                             handleNotificationToggle(enabled)
                         }
@@ -40,7 +41,7 @@ struct SettingsView: View {
                             HStack {
                                 Toggle("", isOn: $time.isEnabled)
                                     .labelsHidden()
-                                    .tint(.cathierAccent)
+                                    .tint(themeManager.accentColor)
                                 Spacer()
                                 DatePicker(
                                     "",
@@ -63,7 +64,7 @@ struct SettingsView: View {
                         Button(lm.settingsSaveReminder) {
                             saveReminderSettings()
                         }
-                        .foregroundColor(.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                     }
                 } header: {
                     Text(lm.settingsRemindersSection)
@@ -116,7 +117,7 @@ struct SettingsView: View {
                         showFeedback = true
                     } label: {
                         Label(lm.feedbackButton, systemImage: "lightbulb")
-                            .foregroundColor(.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                     }
                 }
 
@@ -145,7 +146,7 @@ struct SettingsView: View {
                     Button(lm.detailDone) {
                         isContextBriefFocused = false
                     }
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                 }
             }
         }

--- a/Cathier/Views/TodayView.swift
+++ b/Cathier/Views/TodayView.swift
@@ -13,6 +13,7 @@ struct TodayView: View {
     @AppStorage("notificationsEnabled") private var notificationsEnabled = false
     @State private var showingHealth = false
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
     @State private var healthService = HealthKitService.shared
 
     private var jokeService: JokeService { JokeService.shared }
@@ -254,11 +255,11 @@ struct TodayView: View {
                 HStack(spacing: 14) {
                     ZStack {
                         Circle()
-                            .fill(Color.cathierAccent.opacity(0.15))
+                            .fill(themeManager.accentColor.opacity(0.15))
                             .frame(width: 48, height: 48)
                         Image(systemName: "gearshape.2.fill")
                             .font(.system(size: 20))
-                            .foregroundColor(Color.cathierAccent)
+                            .foregroundColor(themeManager.accentColor)
                     }
                     VStack(alignment: .leading, spacing: 3) {
                         Text(hint)
@@ -349,11 +350,11 @@ struct TodayView: View {
             HStack(spacing: 14) {
                 ZStack {
                     Circle()
-                        .fill(Color.cathierAccent.opacity(0.15))
+                        .fill(themeManager.accentColor.opacity(0.15))
                         .frame(width: 48, height: 48)
                     Image(systemName: "chart.line.uptrend.xyaxis")
                         .font(.system(size: 20))
-                        .foregroundColor(Color.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                 }
                 VStack(alignment: .leading, spacing: 3) {
                     Text(title)
@@ -403,11 +404,11 @@ struct TodayView: View {
             HStack(spacing: 14) {
                 ZStack {
                     Circle()
-                        .fill(Color.cathierAccent.opacity(0.15))
+                        .fill(themeManager.accentColor.opacity(0.15))
                         .frame(width: 48, height: 48)
                     Image(systemName: "book.fill")
                         .font(.system(size: 22))
-                        .foregroundColor(Color.cathierAccent)
+                        .foregroundColor(themeManager.accentColor)
                 }
                 VStack(alignment: .leading, spacing: 3) {
                     Text(lm.journalEntryWritePrompt)
@@ -457,14 +458,14 @@ struct TodayView: View {
             Text("\(streakDays)")
                 .font(.system(.title3, design: .monospaced))
                 .fontWeight(.semibold)
-                .foregroundColor(.cathierAccent)
+                .foregroundColor(themeManager.accentColor)
             Text(lm.streakLabel)
                 .font(.caption2)
                 .foregroundColor(.secondary)
         }
         .frame(width: 56)
         .padding(.vertical, 10)
-        .background(Color.cathierAccentLight)
+        .background(themeManager.accentColor.opacity(0.15))
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 
@@ -525,7 +526,7 @@ struct TodayView: View {
             .padding(.vertical, 28)
             .background(
                 LinearGradient(
-                    colors: [Color.cathierAccent, Color.cathierAccent.opacity(0.75)],
+                    colors: [themeManager.accentColor, themeManager.accentColor.opacity(0.75)],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
@@ -576,7 +577,7 @@ struct TodayView: View {
 
         if snapshot.trend > 0.5 {
             trendIcon = "arrow.up.right"
-            trendColor = .cathierAccent
+            trendColor = themeManager.accentColor
             trendText = lm.currentLanguage == .zh ? "强度上升" : lm.currentLanguage == .ja ? "強度上昇" : "Rising"
         } else if snapshot.trend < -0.5 {
             trendIcon = "arrow.down.right"
@@ -656,7 +657,7 @@ struct TodayView: View {
             HStack(spacing: 12) {
                 Image(systemName: "bell.badge")
                     .font(.title3)
-                    .foregroundColor(.cathierAccent)
+                    .foregroundColor(themeManager.accentColor)
                     .frame(width: 36)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
@@ -673,7 +674,7 @@ struct TodayView: View {
                     .foregroundColor(.secondary)
             }
             .padding(14)
-            .background(Color.cathierAccentLight)
+            .background(themeManager.accentColor.opacity(0.15))
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         }
         .buttonStyle(.plain)
@@ -684,6 +685,7 @@ struct TodayView: View {
 
 private struct TodayIntensityArc: View {
     let checkIns: [CheckIn]
+    @Environment(ThemeManager.self) private var themeManager
 
     private var sorted: [CheckIn] {
         checkIns.sorted { $0.date < $1.date }
@@ -726,7 +728,7 @@ private struct TodayIntensityArc: View {
     private func dotColor(_ intensity: Int) -> Color {
         switch intensity {
         case ..<4: return .yellow
-        case ..<7: return .cathierAccent
+        case ..<7: return themeManager.accentColor
         default:   return .red
         }
     }
@@ -743,6 +745,7 @@ private struct TodayIntensityArc: View {
 private struct WeeklyPracticeRow: View {
     let checkIns: [CheckIn]
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     private var days: [(date: Date, hasCheckIn: Bool)] {
         let cal = Calendar.current
@@ -761,10 +764,10 @@ private struct WeeklyPracticeRow: View {
                 VStack(spacing: 4) {
                     ZStack {
                         Circle()
-                            .stroke(Color.cathierAccent.opacity(isToday ? 0.35 : 0), lineWidth: 1.5)
+                            .stroke(themeManager.accentColor.opacity(isToday ? 0.35 : 0), lineWidth: 1.5)
                             .frame(width: 18, height: 18)
                         Circle()
-                            .fill(day.hasCheckIn ? Color.cathierAccent : Color.secondary.opacity(0.18))
+                            .fill(day.hasCheckIn ? themeManager.accentColor : Color.secondary.opacity(0.18))
                             .frame(width: 9, height: 9)
                     }
                     .frame(width: 18, height: 18)
@@ -792,6 +795,7 @@ private struct WeeklyPracticeRow: View {
 
 private struct WeeklySparkline: View {
     let checkIns: [CheckIn]
+    @Environment(ThemeManager.self) private var themeManager
 
     private let barMaxHeight: CGFloat = 20
     private let barWidth: CGFloat = 10
@@ -830,7 +834,7 @@ private struct WeeklySparkline: View {
     private func barColor(_ intensity: Double) -> Color {
         switch intensity {
         case ..<4: return .yellow
-        case ..<7: return .cathierAccent
+        case ..<7: return themeManager.accentColor
         default:   return .red
         }
     }
@@ -841,6 +845,7 @@ private struct WeeklySparkline: View {
 private struct WeeklyEmotionSummary: View {
     let topEmotions: [(emotion: String, count: Int)]
     @Environment(LanguageManager.self) private var lm
+    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -848,7 +853,7 @@ private struct WeeklyEmotionSummary: View {
                 .font(.headline)
             FlowLayout(spacing: 8) {
                 ForEach(Array(topEmotions.enumerated()), id: \.offset) { _, item in
-                    let color = EmotionData.category(for: item.emotion)?.color ?? .cathierAccent
+                    let color = EmotionData.category(for: item.emotion)?.color ?? themeManager.accentColor
                     let emoji = EmotionData.emoji(for: item.emotion)
                     let name = lm.display(item.emotion)
                     HStack(spacing: 4) {


### PR DESCRIPTION
Every view that was using the hardcoded `Color.cathierAccent` asset (static orange) now reads from `ThemeManager.shared.accentColor` via `@Environment(ThemeManager.self)`.  `ChipView`'s default `color` parameter changes from `.cathierAccent` to `nil`; the body falls back to `themeManager.accentColor` so all body-scan and sensation chips respond to the mood without requiring call-site changes.

Also replaces `Color.cathierAccentLight` with `themeManager.accentColor.opacity(0.15)` everywhere it was used as a tinted background.

The intensity-slider gradient in BodyScanView intentionally keeps the static orange as one stop on the yellow→orange→accent→red scale.