### PR TITLE
feat: add screenshot attachment to feature feedback form

### DIFF
--- a/Cathier/Localization/Strings.swift
+++ b/Cathier/Localization/Strings.swift
@@ -205,9 +205,12 @@ extension LanguageManager {
     var feedbackBodyFooter: String       { localized("feedback.body_footer") }
     var feedbackTokenSection: String     { localized("feedback.token_section") }
     var feedbackTokenFooter: String      { localized("feedback.token_footer") }
-    var feedbackSubmit: String           { localized("feedback.submit") }
-    var feedbackSuccess: String          { localized("feedback.success") }
-    var feedbackViewIssue: String        { localized("feedback.view_issue") }
+    var feedbackSubmit: String              { localized("feedback.submit") }
+    var feedbackSuccess: String             { localized("feedback.success") }
+    var feedbackViewIssue: String           { localized("feedback.view_issue") }
+    var feedbackScreenshotLabel: String     { localized("feedback.screenshot_label") }
+    var feedbackScreenshotAdd: String       { localized("feedback.screenshot_add") }
+    var feedbackScreenshotFooter: String    { localized("feedback.screenshot_footer") }
 
     // MARK: CheckInDetailView
     var detailNavTitle: String        { localized("detail.nav_title") }

--- a/Cathier/Services/GitHubService.swift
+++ b/Cathier/Services/GitHubService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 struct GitHubService {
     static let repoOwner = "jianshuo"
@@ -20,18 +21,74 @@ struct GitHubService {
         Bundle.main.infoDictionary?["GitHubFeedbackPAT"] as? String ?? ""
     }
 
-    static func createFeedbackIssue(title: String, body: String) async throws -> URL {
+    private static func compressedImageData(_ image: UIImage) -> Data? {
+        let maxDimension: CGFloat = 1500
+        var processed = image
+        if max(image.size.width, image.size.height) > maxDimension {
+            let scale = maxDimension / max(image.size.width, image.size.height)
+            let newSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+            let renderer = UIGraphicsImageRenderer(size: newSize)
+            processed = renderer.image { _ in image.draw(in: CGRect(origin: .zero, size: newSize)) }
+        }
+        return processed.jpegData(compressionQuality: 0.7)
+    }
+
+    private static func uploadImage(_ image: UIImage) async throws -> String {
+        guard let imageData = compressedImageData(image) else { throw GitHubError.decodeFailed }
+
+        let filename = "\(UUID().uuidString.lowercased()).jpg"
+        let urlString = "https://api.github.com/repos/\(repoOwner)/\(repoName)/contents/feedback-screenshots/\(filename)"
+        guard let url = URL(string: urlString) else { throw GitHubError.decodeFailed }
+
+        let payload: [String: Any] = [
+            "message": "feedback: add screenshot",
+            "content": imageData.base64EncodedString()
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("Bearer \(bundleToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("2022-11-28", forHTTPHeaderField: "X-GitHub-Api-Version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 201 {
+            throw GitHubError.httpError(httpResponse.statusCode)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let content = json["content"] as? [String: Any],
+              let downloadUrl = content["download_url"] as? String else {
+            throw GitHubError.decodeFailed
+        }
+
+        return downloadUrl
+    }
+
+    static func createFeedbackIssue(title: String, body: String, images: [UIImage] = []) async throws -> URL {
         let resolvedToken = bundleToken
+
+        var imageURLs: [String] = []
+        for image in images {
+            if let imageUrl = try? await uploadImage(image) {
+                imageURLs.append(imageUrl)
+            }
+        }
+
+        var fullBody = body
+        if !imageURLs.isEmpty {
+            let imageMarkdown = imageURLs.enumerated()
+                .map { i, url in "![Screenshot \(i + 1)](\(url))" }
+                .joined(separator: "\n")
+            fullBody += "\n\n### Screenshots\n\n\(imageMarkdown)"
+        }
+        fullBody += "\n\n---\n*Submitted from Cathier app. @claude please implement this feature.*"
 
         let urlString = "https://api.github.com/repos/\(repoOwner)/\(repoName)/issues"
         guard let url = URL(string: urlString) else { throw GitHubError.decodeFailed }
-
-        let fullBody = """
-        \(body)
-
-        ---
-        *Submitted from Cathier app. @claude please implement this feature.*
-        """
 
         let payload: [String: Any] = [
             "title": title,

--- a/Cathier/Views/FeedbackView.swift
+++ b/Cathier/Views/FeedbackView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 struct FeedbackView: View {
     @Environment(LanguageManager.self) private var lm
@@ -9,6 +10,8 @@ struct FeedbackView: View {
     @State private var isSubmitting = false
     @State private var submittedURL: URL?
     @State private var errorMessage: String?
+    @State private var selectedPhotos: [PhotosPickerItem] = []
+    @State private var attachedImages: [UIImage] = []
 
     var body: some View {
         NavigationStack {
@@ -27,6 +30,63 @@ struct FeedbackView: View {
                     Text(lm.feedbackBodyLabel)
                 } footer: {
                     Text(lm.feedbackBodyFooter)
+                        .font(.caption)
+                }
+
+                Section {
+                    if !attachedImages.isEmpty {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(attachedImages.indices, id: \.self) { index in
+                                    ZStack(alignment: .topTrailing) {
+                                        Image(uiImage: attachedImages[index])
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(width: 72, height: 72)
+                                            .clipped()
+                                            .cornerRadius(8)
+                                        Button {
+                                            attachedImages.remove(at: index)
+                                        } label: {
+                                            Image(systemName: "xmark.circle.fill")
+                                                .font(.system(size: 18))
+                                                .foregroundColor(.cathierAccent)
+                                                .background(Color.white.clipShape(Circle()))
+                                        }
+                                        .offset(x: 6, y: -6)
+                                    }
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+
+                    if attachedImages.count < 3 {
+                        PhotosPicker(
+                            selection: $selectedPhotos,
+                            maxSelectionCount: 3 - attachedImages.count,
+                            matching: .images
+                        ) {
+                            Label(lm.feedbackScreenshotAdd, systemImage: "photo.badge.plus")
+                                .foregroundColor(.cathierAccent)
+                        }
+                        .onChange(of: selectedPhotos) { _, items in
+                            Task {
+                                for item in items {
+                                    guard attachedImages.count < 3 else { break }
+                                    if let data = try? await item.loadTransferable(type: Data.self),
+                                       let image = UIImage(data: data) {
+                                        attachedImages.append(image)
+                                    }
+                                }
+                                selectedPhotos = []
+                            }
+                        }
+                    }
+                } header: {
+                    Text(lm.feedbackScreenshotLabel)
+                } footer: {
+                    Text(lm.feedbackScreenshotFooter)
                         .font(.caption)
                 }
 
@@ -78,17 +138,20 @@ struct FeedbackView: View {
         errorMessage = nil
         let trimmedTitle = title.trimmingCharacters(in: .whitespaces)
         let trimmedBody = bodyText.trimmingCharacters(in: .whitespaces)
+        let images = attachedImages
 
         Task {
             do {
                 let url = try await GitHubService.createFeedbackIssue(
                     title: trimmedTitle,
-                    body: trimmedBody
+                    body: trimmedBody,
+                    images: images
                 )
                 await MainActor.run {
                     submittedURL = url
                     title = ""
                     bodyText = ""
+                    attachedImages = []
                     isSubmitting = false
                 }
             } catch {

--- a/Cathier/ar.lproj/Localizable.strings
+++ b/Cathier/ar.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "إعدادات GitHub";
 "feedback.token_footer" = "يلزم رمز الوصول الشخصي GitHub بنطاق 'repo' لإرسال المشكلات. مخزَّن محلياً فقط.";
 "feedback.submit" = "إرسال";
+"feedback.screenshot_label" = "لقطات الشاشة";
+"feedback.screenshot_add" = "إضافة لقطة شاشة";
+"feedback.screenshot_footer" = "أرفق ما يصل إلى 3 لقطات شاشة (اختياري).";
 "feedback.success" = "تم الإرسال بنجاح!";
 "feedback.view_issue" = "عرض GitHub Issue \u2192";
 

--- a/Cathier/de.lproj/Localizable.strings
+++ b/Cathier/de.lproj/Localizable.strings
@@ -203,6 +203,9 @@
 "feedback.submit" = "Einreichen";
 "feedback.success" = "Erfolgreich eingereicht!";
 "feedback.view_issue" = "GitHub Issue ansehen \u2192";
+"feedback.screenshot_label" = "Screenshots";
+"feedback.screenshot_add" = "Screenshot hinzuf\u00fcgen";
+"feedback.screenshot_footer" = "Bis zu 3 Screenshots anh\u00e4ngen (optional).";
 
 /* CheckInDetailView */
 "detail.nav_title" = "Aufzeichnungsdetails";

--- a/Cathier/en.lproj/Localizable.strings
+++ b/Cathier/en.lproj/Localizable.strings
@@ -205,6 +205,9 @@
 "feedback.submit" = "Submit";
 "feedback.success" = "Submitted successfully!";
 "feedback.view_issue" = "View GitHub Issue \u2192";
+"feedback.screenshot_label" = "Screenshots";
+"feedback.screenshot_add" = "Add Screenshot";
+"feedback.screenshot_footer" = "Attach up to 3 screenshots (optional).";
 
 /* CheckInDetailView */
 "detail.nav_title" = "Record Detail";

--- a/Cathier/es.lproj/Localizable.strings
+++ b/Cathier/es.lproj/Localizable.strings
@@ -203,6 +203,9 @@
 "feedback.submit" = "Enviar";
 "feedback.success" = "¡Enviado con éxito!";
 "feedback.view_issue" = "Ver Issue de GitHub \u2192";
+"feedback.screenshot_label" = "Capturas de pantalla";
+"feedback.screenshot_add" = "A\u00f1adir captura";
+"feedback.screenshot_footer" = "Adjunta hasta 3 capturas de pantalla (opcional).";
 
 /* CheckInDetailView */
 "detail.nav_title" = "Detalle del registro";

--- a/Cathier/fr.lproj/Localizable.strings
+++ b/Cathier/fr.lproj/Localizable.strings
@@ -203,6 +203,9 @@
 "feedback.submit" = "Soumettre";
 "feedback.success" = "Soumis avec succès !";
 "feedback.view_issue" = "Voir l'Issue GitHub \u2192";
+"feedback.screenshot_label" = "Captures d'\u00e9cran";
+"feedback.screenshot_add" = "Ajouter une capture";
+"feedback.screenshot_footer" = "Joindre jusqu'\u00e0 3 captures d'\u00e9cran (optionnel).";
 
 /* CheckInDetailView */
 "detail.nav_title" = "Détail de l'enregistrement";

--- a/Cathier/hi.lproj/Localizable.strings
+++ b/Cathier/hi.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "GitHub सेटिंग्स";
 "feedback.token_footer" = "Issues सबमिट करने के लिए 'repo' स्कोप वाला GitHub Personal Access Token आवश्यक है। केवल स्थानीय रूप से संग्रहीत।";
 "feedback.submit" = "सबमिट करें";
+"feedback.screenshot_label" = "स्क्रीनशॉट";
+"feedback.screenshot_add" = "स्क्रीनशॉट जोड़ें";
+"feedback.screenshot_footer" = "अधिकतम 3 स्क्रीनशॉट संलग्न करें (वैकल्पिक)।";
 "feedback.success" = "सफलतापूर्वक सबमिट किया गया!";
 "feedback.view_issue" = "GitHub Issue देखें \u2192";
 

--- a/Cathier/it.lproj/Localizable.strings
+++ b/Cathier/it.lproj/Localizable.strings
@@ -203,6 +203,9 @@
 "feedback.submit" = "Invia";
 "feedback.success" = "Inviato con successo!";
 "feedback.view_issue" = "Visualizza Issue GitHub \u2192";
+"feedback.screenshot_label" = "Screenshot";
+"feedback.screenshot_add" = "Aggiungi screenshot";
+"feedback.screenshot_footer" = "Allega fino a 3 screenshot (opzionale).";
 
 /* CheckInDetailView */
 "detail.nav_title" = "Dettaglio registrazione";

--- a/Cathier/ja.lproj/Localizable.strings
+++ b/Cathier/ja.lproj/Localizable.strings
@@ -205,6 +205,9 @@
 "feedback.submit" = "送信";
 "feedback.success" = "送信成功！";
 "feedback.view_issue" = "GitHub Issueを見る →";
+"feedback.screenshot_label" = "スクリーンショット";
+"feedback.screenshot_add" = "スクリーンショットを追加";
+"feedback.screenshot_footer" = "最大3枚のスクリーンショットを添付できます（任意）。";
 
 /* CheckInDetailView */
 "detail.nav_title" = "記録の詳細";

--- a/Cathier/ko.lproj/Localizable.strings
+++ b/Cathier/ko.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "GitHub 설정";
 "feedback.token_footer" = "이슈 제출을 위해 'repo' 범위의 GitHub 개인 액세스 토큰이 필요합니다. 로컬에만 저장됩니다.";
 "feedback.submit" = "제출";
+"feedback.screenshot_label" = "스크린샷";
+"feedback.screenshot_add" = "스크린샷 추가";
+"feedback.screenshot_footer" = "스크린샷을 최대 3장 첨부할 수 있습니다 (선택 사항).";
 "feedback.success" = "성공적으로 제출됐어요!";
 "feedback.view_issue" = "GitHub Issue 보기 \u2192";
 

--- a/Cathier/pt.lproj/Localizable.strings
+++ b/Cathier/pt.lproj/Localizable.strings
@@ -203,6 +203,9 @@
 "feedback.submit" = "Enviar";
 "feedback.success" = "Enviado com sucesso!";
 "feedback.view_issue" = "Ver Issue do GitHub \u2192";
+"feedback.screenshot_label" = "Capturas de tela";
+"feedback.screenshot_add" = "Adicionar captura";
+"feedback.screenshot_footer" = "Anexe at\u00e9 3 capturas de tela (opcional).";
 
 /* CheckInDetailView */
 "detail.nav_title" = "Detalhe do registro";

--- a/Cathier/ru.lproj/Localizable.strings
+++ b/Cathier/ru.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "Настройки GitHub";
 "feedback.token_footer" = "Для отправки issues требуется личный токен доступа GitHub с областью 'repo'. Хранится только локально.";
 "feedback.submit" = "Отправить";
+"feedback.screenshot_label" = "Снимки экрана";
+"feedback.screenshot_add" = "Добавить снимок";
+"feedback.screenshot_footer" = "Прикрепите до 3 снимков экрана (необязательно).";
 "feedback.success" = "Успешно отправлено!";
 "feedback.view_issue" = "Посмотреть GitHub Issue \u2192";
 

--- a/Cathier/th.lproj/Localizable.strings
+++ b/Cathier/th.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "การตั้งค่า GitHub";
 "feedback.token_footer" = "ต้องใช้ GitHub Personal Access Token ที่มีขอบเขต 'repo' เพื่อส่ง Issues จัดเก็บในเครื่องเท่านั้น";
 "feedback.submit" = "ส่ง";
+"feedback.screenshot_label" = "ภาพหน้าจอ";
+"feedback.screenshot_add" = "เพิ่มภาพหน้าจอ";
+"feedback.screenshot_footer" = "แนบภาพหน้าจอได้สูงสุด 3 ภาพ (ไม่บังคับ)";
 "feedback.success" = "ส่งสำเร็จ!";
 "feedback.view_issue" = "ดู GitHub Issue \u2192";
 

--- a/Cathier/tr.lproj/Localizable.strings
+++ b/Cathier/tr.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "GitHub Ayarları";
 "feedback.token_footer" = "Issue göndermek için 'repo' kapsamlı GitHub Kişisel Erişim Tokenı gereklidir. Yalnızca yerel olarak saklanır.";
 "feedback.submit" = "Gönder";
+"feedback.screenshot_label" = "Ekran Görüntüleri";
+"feedback.screenshot_add" = "Ekran görüntüsü ekle";
+"feedback.screenshot_footer" = "İsteğe bağlı olarak en fazla 3 ekran görüntüsü ekleyin.";
 "feedback.success" = "Başarıyla gönderildi!";
 "feedback.view_issue" = "GitHub Issue'yu Görüntüle \u2192";
 

--- a/Cathier/vi.lproj/Localizable.strings
+++ b/Cathier/vi.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 "feedback.token_section" = "Cài đặt GitHub";
 "feedback.token_footer" = "Cần GitHub Personal Access Token với phạm vi 'repo' để gửi issues. Chỉ lưu cục bộ.";
 "feedback.submit" = "Gửi";
+"feedback.screenshot_label" = "Ảnh chụp màn hình";
+"feedback.screenshot_add" = "Thêm ảnh chụp";
+"feedback.screenshot_footer" = "Đính kèm tối đa 3 ảnh chụp màn hình (tùy chọn).";
 "feedback.success" = "Đã gửi thành công!";
 "feedback.view_issue" = "Xem GitHub Issue \u2192";
 

--- a/Cathier/zh.lproj/Localizable.strings
+++ b/Cathier/zh.lproj/Localizable.strings
@@ -205,6 +205,9 @@
 "feedback.submit" = "提交";
 "feedback.success" = "提交成功！";
 "feedback.view_issue" = "查看 GitHub Issue →";
+"feedback.screenshot_label" = "截图";
+"feedback.screenshot_add" = "添加截图";
+"feedback.screenshot_footer" = "可附上最多 3 张截图（可选）。";
 
 /* CheckInDetailView */
 "detail.nav_title" = "记录详情";


### PR DESCRIPTION
Users can now attach up to 3 screenshots when submitting feature suggestions. Images are uploaded to the repo via GitHub Contents API and embedded inline in the GitHub Issue body.