### PR TITLE
fix: 广场分享/加载失败暴露给用户，不再静默吞掉

### DIFF
--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -16,6 +16,8 @@ struct AIFeedbackView: View {
     @State private var plazaTier: FriendCheckIn.PrivacyTier = .emotions
     @State private var showExercise = false
     @State private var aiFeedbackCopied = false
+    @State private var isSavingPlaza = false
+    @State private var plazaError: String?
 
     private var hasFriends: Bool { friendVM.currentProfile != nil && !friendVM.friends.isEmpty }
     private var hasProfile: Bool { friendVM.currentProfile != nil }
@@ -58,15 +60,22 @@ struct AIFeedbackView: View {
                 }
 
                 Button(action: saveAction) {
-                    Text(lm.aiSave)
-                        .font(.headline)
-                        .foregroundColor(.white)
+                    Group {
+                        if isSavingPlaza {
+                            ProgressView().tint(.white)
+                        } else {
+                            Text(lm.aiSave)
+                                .font(.headline)
+                                .foregroundColor(.white)
+                        }
+                    }
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
                 .background(Color.cathierAccent)
                 .clipShape(Capsule())
                 .padding(.top, 8)
+                .disabled(isSavingPlaza)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 32)
@@ -83,6 +92,14 @@ struct AIFeedbackView: View {
                 let freq = emotionFrequency()
                 await viewModel.fetchAIFeedback(recentHistory: history, emotionFrequency: freq)
             }
+        }
+        .alert("分享到广场失败", isPresented: Binding(
+            get: { plazaError != nil },
+            set: { if !$0 { plazaError = nil } }
+        )) {
+            Button("好", role: .cancel) { plazaError = nil }
+        } message: {
+            Text(plazaError ?? "")
         }
         .sheet(isPresented: $showExercise) {
             MicroExerciseView(
@@ -350,12 +367,29 @@ struct AIFeedbackView: View {
             let includeAI = tier == .full ? false : shareAIFeedback
             Task { try? await friendVM.shareCheckIn(checkIn, tier: tier, shareAIFeedback: includeAI) }
         }
-        if shareToPlaza, let profile = friendVM.currentProfile {
-            let post = PlazaPost(ownerProfile: profile, checkIn: checkIn, privacyTier: plazaTier, shareAIFeedback: plazaTier == .full)
-            checkIn.isPlazaShared = true
-            Task { try? await CloudKitService.shared.savePlazaPost(post) }
+        guard shareToPlaza, let profile = friendVM.currentProfile else {
+            onDismiss()
+            return
         }
-        onDismiss()
+        // Plaza share: await the upload so failures surface to the user instead
+        // of being silently swallowed. isPlazaShared is only flipped on success.
+        let post = PlazaPost(ownerProfile: profile, checkIn: checkIn, privacyTier: plazaTier, shareAIFeedback: plazaTier == .full)
+        isSavingPlaza = true
+        Task {
+            do {
+                try await CloudKitService.shared.savePlazaPost(post)
+                await MainActor.run {
+                    checkIn.isPlazaShared = true
+                    isSavingPlaza = false
+                    onDismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    isSavingPlaza = false
+                    plazaError = error.localizedDescription
+                }
+            }
+        }
     }
 
     // MARK: - Summary Card

--- a/Cathier/Views/Plaza/PlazaView.swift
+++ b/Cathier/Views/Plaza/PlazaView.swift
@@ -64,6 +64,8 @@ private struct PlazaFeedView: View {
             if plazaVM.isLoading && plazaVM.posts.isEmpty {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let error = plazaVM.error, plazaVM.posts.isEmpty {
+                errorView(error)
             } else if plazaVM.posts.isEmpty {
                 emptyView
             } else {
@@ -77,6 +79,29 @@ private struct PlazaFeedView: View {
                 Task { await plazaVM.load() }
             }
         }
+    }
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundColor(.cathierAccent)
+            Text("加载广场失败")
+                .font(.headline)
+            Text(message)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button {
+                Task { await plazaVM.load(force: true) }
+            } label: {
+                Text(lm.friendRetry)
+                    .font(.subheadline)
+                    .foregroundColor(.cathierAccent)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var feedList: some View {


### PR DESCRIPTION
## 问题
分享到广场后广场仍然空空如也，因为代码里两个错误处理都是 \`try?\` 把失败吞掉了：

\`AIFeedbackView.saveAction\`:
- \`Task { try? await CloudKitService.shared.savePlazaPost(post) }\` ← 失败 silent
- \`checkIn.isPlazaShared = true\` ← 在写入前就设了，UI 看上去"已分享"

\`PlazaViewModel.load\`:
- 写入到 \`self.error\` 但 \`PlazaFeedView\` 从来没渲染这个字段
- 加载失败和"真的就是没人发"长得一模一样

## 改动
**AIFeedbackView**
- 把 plaza 写入改成 await，失败时弹 alert 显示具体错误，按"好"再退出
- \`isPlazaShared\` 只在写入成功后才置 true
- 写入期间显示 ProgressView 并 disable Save 按钮

**PlazaView**
- 增加 errorView 分支：\`plazaVM.error\` 非空且 posts 为空时显示错误 + 重试按钮
- 替代之前的纯空状态

## 测试
- [x] xcodebuild simulator 编译通过
- [ ] 实机／模拟器：把 CloudKit 索引故意去掉验证错误能正确显示
- [ ] 索引补齐后验证正常分享流程

## 注意
这个 PR **不修复**广场为空的根本原因（CloudKit Dashboard 需要给 PlazaPost 建索引）——它只是让错误**可见**。索引配置步骤在对话里另外说明。