### PR TITLE
fix: restore id-token: write to marketing-daily workflow

### DIFF
--- a/.github/workflows/marketing-daily.yml
+++ b/.github/workflows/marketing-daily.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       issues: write
+      id-token: write  # Required by anthropics/claude-code-action@v1 for OIDC auth
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Bug fix: workflow_dispatch run on PR #76 failed because `id-token: write` permission was missing
- `anthropics/claude-code-action@v1` requires OIDC token auth — without this permission it errors with `Could not fetch an OIDC token`
- Mistakenly removed during the "final review fixes" commit (reviewer incorrectly thought it was unused)
- Restoring it; one-line fix

## Test plan
- [ ] CI passes
- [ ] Merge → re-run `gh workflow run marketing-daily.yml` → should succeed past the OIDC step

🤖 Generated with [Claude Code](https://claude.com/claude-code)