### PR TITLE
fix: allowlist tools in marketing-daily Claude Code action

### DIFF
--- a/.github/workflows/marketing-daily.yml
+++ b/.github/workflows/marketing-daily.yml
@@ -53,6 +53,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allowlist the tools the orchestrator actually needs. Without this,
+          # the SDK's default permission mode deadlocks every tool call in headless
+          # workflow_dispatch (29 denials + $1.57 wasted on the first run).
+          claude_args: "--allowedTools Bash Read Write Edit Grep Glob"
+          show_full_output: "true"
           prompt: |
             Read marketing/prompts/daily-orchestrator.md and execute it.
             Today's date: ${{ steps.date.outputs.today }}


### PR DESCRIPTION
Previous workflow_dispatch had permission_denials_count: 29, burned $1.57 doing nothing.

Default permission mode deadlocks every tool call in headless workflow_dispatch. Fix:
- `claude_args: '--allowedTools Bash Read Write Edit Grep Glob'` — allowlist the tools orchestrator needs
- `show_full_output: 'true'` — so logs show what Claude actually does

Test plan:
- CI passes
- Merge → re-run `gh workflow run marketing-daily.yml`
- Should commit marketing/posts/today/ + open marketing-ready issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)