### PR TITLE
@claude implement: 身体情绪记录完生成一个音频引导语 (closes #74)

### DIFF
--- a/Cathier/Localization/Strings.swift
+++ b/Cathier/Localization/Strings.swift
@@ -90,6 +90,19 @@ extension LanguageManager {
     var exerciseTryThis: String   { localized("exercise.try_this") }
     var exerciseTryHint: String   { localized("exercise.try_hint") }
 
+    // MARK: GuidedMeditationView
+    var meditationNavTitle: String { localized("meditation.nav_title") }
+    var meditationLoading: String  { localized("meditation.loading") }
+    var meditationRetry: String    { localized("meditation.retry") }
+    var meditationPlay: String     { localized("meditation.play") }
+    var meditationPause: String    { localized("meditation.pause") }
+    var meditationResume: String   { localized("meditation.resume") }
+    var meditationStop: String     { localized("meditation.stop") }
+    var meditationDone: String     { localized("meditation.done") }
+    var meditationClose: String    { localized("meditation.close") }
+    var meditationTryThis: String  { localized("meditation.try_this") }
+    var meditationTryHint: String  { localized("meditation.try_hint") }
+
     // MARK: Privacy Tier
     var tierCategoryName: String        { localized("tier.category_name") }
     var tierCategoryDesc: String        { localized("tier.category_desc") }

--- a/Cathier/Services/ClaudeService.swift
+++ b/Cathier/Services/ClaudeService.swift
@@ -690,6 +690,82 @@ enum ClaudeService {
         return try await call(model: feedbackModel, system: system, user: user, maxTokens: 2000)
     }
 
+    // MARK: - Guided Meditation
+
+    static func generateGuidedMeditation(
+        bodyParts: [String],
+        sensations: [String],
+        emotions: [String],
+        language: AppLanguage = LanguageManager.shared.currentLanguage
+    ) async throws -> String {
+        let lm = LanguageManager.shared
+        let parsed = parseBodySensations(sensations)
+
+        let system: String
+        let user: String
+
+        switch language {
+        case .zh:
+            system = """
+            你是「觉察」App 的引导冥想导师。用户刚完成了身体扫描和情绪标注，现在需要一段约3分钟的音频引导语，带领他们做身体扫描和情绪观想练习。
+
+            要求：
+            - 引导语必须针对用户具体的身体部位、感受和情绪——完全个性化
+            - 用第二人称"你"，语气温柔、缓慢，像在用户耳边轻声引导
+            - 结构：①安定（找到舒适姿势，专注呼吸）→ ②身体扫描（逐一关注用户记录的身体部位）→ ③情绪观想（看见并接纳用户记录的情绪）→ ④收尾整合
+            - 不使用任何 Markdown 格式，不加星号、井号、标题——只有流畅的引导语段落
+            - 语言流畅自然，适合朗读，停顿用省略号（……）表示
+            - 核心理念：不是要消除感受，而是"看见"它、"和它在一起"
+            - 总长度约300-450字，节奏舒缓，适合约3分钟的朗读
+            - 用中文回应
+            """
+            let partsStr = bodyParts.isEmpty ? "整个身体" : bodyParts.joined(separator: "、")
+            let emosStr = emotions.isEmpty ? "当下的感受" : emotions.joined(separator: "、")
+            var sensesStr = ""
+            if !parsed.perPart.isEmpty {
+                sensesStr = parsed.perPart.map { "\($0.part)：\($0.sensations.joined(separator: "、"))" }.joined(separator: "；")
+            }
+            user = "身体部位：\(partsStr)\n感受：\(sensesStr.isEmpty ? "未指定" : sensesStr)\n情绪：\(emosStr)\n\n请为我生成一段个性化的引导冥想语，帮助我做身体扫描和情绪观想。"
+
+        case .ja:
+            system = """
+            あなたはCathier（覚察）アプリのガイド瞑想インストラクターです。ユーザーはボディスキャンと感情ラベリングを完了したばかりです。約3分間の音声ガイドスクリプトを生成し、ボディスキャンと感情観想の練習を導いてください。
+
+            要件：
+            - ユーザーの具体的な身体部位、感覚、感情に完全に合わせた個性化された内容
+            - 「あなた」を使い、耳元で優しく導くような、穏やかでゆっくりとした語り口
+            - 構成：①安定（楽な姿勢を見つけ、呼吸に集中）→ ②ボディスキャン（ユーザーが記録した部位を順に感じる）→ ③感情観想（感情を見つめ、受け入れる）→ ④締めくくり
+            - Markdownは使用しない——滑らかなガイド文のみ
+            - 読み上げに適した自然な日本語、間は「……」で示す
+            - 約300〜400文字、ゆっくりとした朗読で約3分
+            - 日本語で回答
+            """
+            let partsStr = bodyParts.map { lm.display($0) }.joined(separator: "、")
+            let emosStr = emotions.map { lm.display($0) }.joined(separator: "、")
+            user = "身体部位：\(partsStr.isEmpty ? "全身" : partsStr)\n感情：\(emosStr.isEmpty ? "今の感情" : emosStr)\n\n個性化されたガイド瞑想スクリプトを生成してください。"
+
+        default:
+            system = """
+            You are the guided meditation instructor for Cathier — an emotion perception training app. The user just completed a body scan and emotion labeling. Generate a ~3-minute audio guidance script to lead them through a personalized body scan and emotion visualization practice.
+
+            Requirements:
+            - Fully personalized to the user's specific body areas, sensations, and emotions
+            - Use "you", gentle and slow tone — as if speaking softly beside them
+            - Structure: ①Settle (find comfort, focus on breath) → ②Body Scan (attend to each recorded body area) → ③Emotion Visualization (see and accept the labeled emotions) → ④Integration & close
+            - No Markdown formatting — only flowing, spoken-word paragraphs
+            - Natural language suitable for audio, use "..." for pauses
+            - Core philosophy: not about eliminating sensations, but "seeing" them and "being with" them
+            - Total ~250-350 words, paced for ~3 minutes of reading aloud
+            - Respond in English
+            """
+            let partsStr = bodyParts.map { lm.display($0) }.joined(separator: ", ")
+            let emosStr = emotions.map { lm.display($0) }.joined(separator: ", ")
+            user = "Body areas: \(partsStr.isEmpty ? "whole body" : partsStr)\nEmotions: \(emosStr.isEmpty ? "present feelings" : emosStr)\n\nPlease generate a personalized guided meditation script for me."
+        }
+
+        return try await call(model: feedbackModel, system: system, user: user, maxTokens: 2500)
+    }
+
     // MARK: - Health Insights
 
     static func generateHealthInsights(

--- a/Cathier/Views/CheckIn/AIFeedbackView.swift
+++ b/Cathier/Views/CheckIn/AIFeedbackView.swift
@@ -15,6 +15,7 @@ struct AIFeedbackView: View {
     @State private var selectedPlazaTier: FriendCheckIn.PrivacyTier? = nil
     @State private var shareAIFeedback: Bool = false
     @State private var showExercise = false
+    @State private var showMeditation = false
     @State private var aiFeedbackCopied = false
     @State private var isSavingPlaza = false
     @State private var plazaError: String?
@@ -37,6 +38,7 @@ struct AIFeedbackView: View {
 
                 if !viewModel.aiFeedback.isEmpty && !viewModel.isLoadingAI {
                     exerciseButton
+                    meditationButton
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -113,6 +115,14 @@ struct AIFeedbackView: View {
             )
             .environment(lm)
         }
+        .sheet(isPresented: $showMeditation) {
+            GuidedMeditationView(
+                bodyParts: Array(viewModel.selectedBodyParts),
+                sensations: viewModel.encodedSensations,
+                emotions: viewModel.allEmotions
+            )
+            .environment(lm)
+        }
     }
 
     // MARK: - Micro-exercise button
@@ -129,6 +139,35 @@ struct AIFeedbackView: View {
                         .fontWeight(.medium)
                         .foregroundColor(.primary)
                     Text(lm.exerciseTryHint)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(14)
+            .background(Color.cathierAccentLight)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Guided meditation button
+
+    private var meditationButton: some View {
+        Button(action: { showMeditation = true }) {
+            HStack(spacing: 10) {
+                Image(systemName: "ear")
+                    .font(.subheadline)
+                    .foregroundColor(.cathierAccent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(lm.meditationTryThis)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                    Text(lm.meditationTryHint)
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }

--- a/Cathier/Views/CheckIn/GuidedMeditationView.swift
+++ b/Cathier/Views/CheckIn/GuidedMeditationView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+import AVFoundation
+
+// MARK: - Speech manager (NSObject subclass required for AVSpeechSynthesizerDelegate)
+
+@Observable
+private final class MeditationSpeechManager: NSObject, AVSpeechSynthesizerDelegate {
+    enum PlayState { case idle, playing, paused, done }
+
+    var playState: PlayState = .idle
+
+    private let synthesizer = AVSpeechSynthesizer()
+
+    override init() {
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    func play(text: String, language: AppLanguage) {
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: voiceLocale(for: language))
+        utterance.rate = 0.40
+        utterance.pitchMultiplier = 1.0
+        utterance.volume = 1.0
+        utterance.postUtteranceDelay = 0.5
+
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        try? AVAudioSession.sharedInstance().setActive(true)
+
+        synthesizer.speak(utterance)
+        playState = .playing
+    }
+
+    func pause() {
+        synthesizer.pauseSpeaking(at: .word)
+        playState = .paused
+    }
+
+    func resume() {
+        synthesizer.continueSpeaking()
+        playState = .playing
+    }
+
+    func stop() {
+        synthesizer.stopSpeaking(at: .immediate)
+        playState = .idle
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    // MARK: AVSpeechSynthesizerDelegate
+
+    func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        playState = .done
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func voiceLocale(for language: AppLanguage) -> String {
+        switch language {
+        case .zh: return "zh-CN"
+        case .ja: return "ja-JP"
+        case .ko: return "ko-KR"
+        case .fr: return "fr-FR"
+        case .de: return "de-DE"
+        case .es: return "es-ES"
+        case .it: return "it-IT"
+        case .pt: return "pt-BR"
+        case .ru: return "ru-RU"
+        case .ar: return "ar-SA"
+        case .hi: return "hi-IN"
+        case .th: return "th-TH"
+        case .vi: return "vi-VN"
+        case .tr: return "tr-TR"
+        default:  return "en-US"
+        }
+    }
+}
+
+// MARK: - GuidedMeditationView
+
+struct GuidedMeditationView: View {
+    let bodyParts: [String]
+    let sensations: [String]
+    let emotions: [String]
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(LanguageManager.self) private var lm
+
+    @State private var script: String = ""
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+    @State private var speechManager = MeditationSpeechManager()
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    if isLoading {
+                        loadingView
+                    } else if let error = errorMessage {
+                        errorView(error)
+                    } else {
+                        meditationContent
+                    }
+                }
+                .padding(20)
+            }
+            .navigationTitle(lm.meditationNavTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: stopAndDismiss) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .task { await loadScript() }
+        .onDisappear { speechManager.stop() }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.4)
+                .tint(.cathierAccent)
+            Text(lm.meditationLoading)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+
+    // MARK: - Error
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 36))
+                .foregroundColor(.cathierAccent)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            Button(lm.meditationRetry) {
+                Task { await loadScript() }
+            }
+            .foregroundColor(.cathierAccent)
+        }
+        .padding(.vertical, 40)
+    }
+
+    // MARK: - Meditation content
+
+    private var meditationContent: some View {
+        VStack(spacing: 24) {
+            Text(script)
+                .font(.cathierSerif(.body))
+                .lineSpacing(6)
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.cathierAccentLight)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            audioControls
+        }
+    }
+
+    // MARK: - Audio controls
+
+    private var audioControls: some View {
+        VStack(spacing: 16) {
+            switch speechManager.playState {
+            case .idle:
+                Button(action: { speechManager.play(text: script, language: lm.currentLanguage) }) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "play.fill")
+                        Text(lm.meditationPlay)
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Color.cathierAccent)
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                }
+
+            case .playing:
+                VStack(spacing: 12) {
+                    playingIndicator
+
+                    HStack(spacing: 16) {
+                        Button(action: { speechManager.pause() }) {
+                            HStack(spacing: 6) {
+                                Image(systemName: "pause.fill")
+                                Text(lm.meditationPause)
+                                    .fontWeight(.semibold)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.cathierAccent)
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                        }
+
+                        Button(action: { speechManager.stop() }) {
+                            Text(lm.meditationStop)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+
+            case .paused:
+                HStack(spacing: 16) {
+                    Button(action: { speechManager.resume() }) {
+                        HStack(spacing: 6) {
+                            Image(systemName: "play.fill")
+                            Text(lm.meditationResume)
+                                .fontWeight(.semibold)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Color.cathierAccent)
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 14))
+                    }
+
+                    Button(action: { speechManager.stop() }) {
+                        Text(lm.meditationStop)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+            case .done:
+                VStack(spacing: 12) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 40))
+                        .foregroundColor(.cathierAccent)
+                    Text(lm.meditationDone)
+                        .font(.headline)
+                        .foregroundColor(.cathierAccent)
+                    Button(action: stopAndDismiss) {
+                        Text(lm.meditationClose)
+                            .fontWeight(.semibold)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.cathierAccent)
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 14))
+                    }
+                }
+            }
+        }
+    }
+
+    private var playingIndicator: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<5, id: \.self) { i in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.cathierAccent)
+                    .frame(width: 4, height: CGFloat.random(in: 12...28))
+                    .animation(
+                        .easeInOut(duration: 0.5)
+                        .repeatForever()
+                        .delay(Double(i) * 0.1),
+                        value: speechManager.playState
+                    )
+            }
+        }
+        .frame(height: 32)
+    }
+
+    // MARK: - Load script
+
+    private func loadScript() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            script = try await ClaudeService.generateGuidedMeditation(
+                bodyParts: bodyParts,
+                sensations: sensations,
+                emotions: emotions,
+                language: lm.currentLanguage
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func stopAndDismiss() {
+        speechManager.stop()
+        dismiss()
+    }
+}

--- a/Cathier/ar.lproj/Localizable.strings
+++ b/Cathier/ar.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "التأمل الموجه";
+"meditation.loading" = "جارٍ إنشاء النص الإرشادي…";
+"meditation.retry" = "إعادة المحاولة";
+"meditation.play" = "تشغيل الإرشاد";
+"meditation.pause" = "إيقاف مؤقت";
+"meditation.resume" = "استئناف";
+"meditation.stop" = "إيقاف";
+"meditation.done" = "اكتمل الإرشاد";
+"meditation.close" = "إغلاق";
+"meditation.try_this" = "التأمل الموجه";
+"meditation.try_hint" = "مسح الجسم وتصور المشاعر، ~٣ دقائق";

--- a/Cathier/de.lproj/Localizable.strings
+++ b/Cathier/de.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Geführte Meditation";
+"meditation.loading" = "Führungsskript wird erstellt…";
+"meditation.retry" = "Erneut versuchen";
+"meditation.play" = "Führung abspielen";
+"meditation.pause" = "Pause";
+"meditation.resume" = "Fortsetzen";
+"meditation.stop" = "Stopp";
+"meditation.done" = "Führung abgeschlossen";
+"meditation.close" = "Schließen";
+"meditation.try_this" = "Geführte Meditation";
+"meditation.try_hint" = "Körperscan und Emotionsvisualisierung, ~3 Min";

--- a/Cathier/en.lproj/Localizable.strings
+++ b/Cathier/en.lproj/Localizable.strings
@@ -275,3 +275,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Guided Meditation";
+"meditation.loading" = "Generating your guided script…";
+"meditation.retry" = "Try Again";
+"meditation.play" = "Play Guidance";
+"meditation.pause" = "Pause";
+"meditation.resume" = "Resume";
+"meditation.stop" = "Stop";
+"meditation.done" = "Guidance Complete";
+"meditation.close" = "Close";
+"meditation.try_this" = "Guided Meditation";
+"meditation.try_hint" = "Body scan & emotion visualization, ~3 min";

--- a/Cathier/es.lproj/Localizable.strings
+++ b/Cathier/es.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Meditación Guiada";
+"meditation.loading" = "Generando tu guía…";
+"meditation.retry" = "Reintentar";
+"meditation.play" = "Reproducir guía";
+"meditation.pause" = "Pausar";
+"meditation.resume" = "Continuar";
+"meditation.stop" = "Detener";
+"meditation.done" = "Guía completada";
+"meditation.close" = "Cerrar";
+"meditation.try_this" = "Meditación guiada";
+"meditation.try_hint" = "Escaneo corporal y visualización emocional, ~3 min";

--- a/Cathier/fr.lproj/Localizable.strings
+++ b/Cathier/fr.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "La Place voit la catégorie et l'intensité seulement";
 "plaza.tier_emotions_desc" = "La Place voit les mots d'émotion spécifiques";
 "plaza.tier_full_desc" = "La Place voit tout, y compris les notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Méditation Guidée";
+"meditation.loading" = "Génération de votre script guidé…";
+"meditation.retry" = "Réessayer";
+"meditation.play" = "Lire le guide";
+"meditation.pause" = "Pause";
+"meditation.resume" = "Reprendre";
+"meditation.stop" = "Arrêter";
+"meditation.done" = "Guidage terminé";
+"meditation.close" = "Fermer";
+"meditation.try_this" = "Méditation guidée";
+"meditation.try_hint" = "Scan corporel et visualisation émotionnelle, ~3 min";

--- a/Cathier/hi.lproj/Localizable.strings
+++ b/Cathier/hi.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "निर्देशित ध्यान";
+"meditation.loading" = "आपकी गाइड स्क्रिप्ट बनाई जा रही है…";
+"meditation.retry" = "पुनः प्रयास करें";
+"meditation.play" = "गाइड चलाएं";
+"meditation.pause" = "रोकें";
+"meditation.resume" = "जारी रखें";
+"meditation.stop" = "बंद करें";
+"meditation.done" = "गाइड पूर्ण";
+"meditation.close" = "बंद करें";
+"meditation.try_this" = "निर्देशित ध्यान";
+"meditation.try_hint" = "बॉडी स्कैन और भावना विज़ुअलाइज़ेशन, ~3 मिनट";

--- a/Cathier/it.lproj/Localizable.strings
+++ b/Cathier/it.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Meditazione Guidata";
+"meditation.loading" = "Creazione dello script guidato…";
+"meditation.retry" = "Riprova";
+"meditation.play" = "Riproduci guida";
+"meditation.pause" = "Pausa";
+"meditation.resume" = "Riprendi";
+"meditation.stop" = "Stop";
+"meditation.done" = "Guida completata";
+"meditation.close" = "Chiudi";
+"meditation.try_this" = "Meditazione guidata";
+"meditation.try_hint" = "Scansione corporea e visualizzazione emotiva, ~3 min";

--- a/Cathier/ja.lproj/Localizable.strings
+++ b/Cathier/ja.lproj/Localizable.strings
@@ -275,3 +275,16 @@
 "plaza.tier_category_desc" = "広場には感情カテゴリと強度のみ表示";
 "plaza.tier_emotions_desc" = "広場には具体的な感情ワードを表示";
 "plaza.tier_full_desc" = "広場にはメモを含む全内容を表示";
+
+/* Guided Meditation */
+"meditation.nav_title" = "ガイド瞑想";
+"meditation.loading" = "ガイドスクリプトを生成中…";
+"meditation.retry" = "再試行";
+"meditation.play" = "ガイドを再生";
+"meditation.pause" = "一時停止";
+"meditation.resume" = "再開";
+"meditation.stop" = "終了";
+"meditation.done" = "ガイド完了";
+"meditation.close" = "閉じる";
+"meditation.try_this" = "ガイド瞑想";
+"meditation.try_hint" = "ボディスキャンと感情観想、約3分";

--- a/Cathier/ko.lproj/Localizable.strings
+++ b/Cathier/ko.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "광장에서 감정 카테고리와 강도만 표시";
 "plaza.tier_emotions_desc" = "광장에서 구체적인 감정 단어 표시";
 "plaza.tier_full_desc" = "메모 포함 모든 내용 표시";
+
+/* Guided Meditation */
+"meditation.nav_title" = "가이드 명상";
+"meditation.loading" = "가이드 스크립트 생성 중…";
+"meditation.retry" = "다시 시도";
+"meditation.play" = "가이드 재생";
+"meditation.pause" = "일시정지";
+"meditation.resume" = "계속";
+"meditation.stop" = "종료";
+"meditation.done" = "가이드 완료";
+"meditation.close" = "닫기";
+"meditation.try_this" = "가이드 명상";
+"meditation.try_hint" = "신체 스캔 및 감정 시각화, 약 3분";

--- a/Cathier/pt.lproj/Localizable.strings
+++ b/Cathier/pt.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Praça vê apenas categoria e intensidade";
 "plaza.tier_emotions_desc" = "Praça vê palavras de emoção específicas";
 "plaza.tier_full_desc" = "Praça vê tudo, incluindo notas";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Meditação Guiada";
+"meditation.loading" = "Gerando seu script guiado…";
+"meditation.retry" = "Tentar novamente";
+"meditation.play" = "Reproduzir guia";
+"meditation.pause" = "Pausar";
+"meditation.resume" = "Retomar";
+"meditation.stop" = "Parar";
+"meditation.done" = "Guia concluído";
+"meditation.close" = "Fechar";
+"meditation.try_this" = "Meditação guiada";
+"meditation.try_hint" = "Escaneamento corporal e visualização emocional, ~3 min";

--- a/Cathier/ru.lproj/Localizable.strings
+++ b/Cathier/ru.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Площадь видит только категорию и интенсивность";
 "plaza.tier_emotions_desc" = "Площадь видит конкретные эмоции";
 "plaza.tier_full_desc" = "Площадь видит всё, включая заметки";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Управляемая медитация";
+"meditation.loading" = "Создание сценария…";
+"meditation.retry" = "Повторить";
+"meditation.play" = "Воспроизвести";
+"meditation.pause" = "Пауза";
+"meditation.resume" = "Продолжить";
+"meditation.stop" = "Стоп";
+"meditation.done" = "Завершено";
+"meditation.close" = "Закрыть";
+"meditation.try_this" = "Управляемая медитация";
+"meditation.try_hint" = "Сканирование тела и визуализация эмоций, ~3 мин";

--- a/Cathier/th.lproj/Localizable.strings
+++ b/Cathier/th.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "การทำสมาธิแบบมีคำแนะนำ";
+"meditation.loading" = "กำลังสร้างสคริปต์คำแนะนำ…";
+"meditation.retry" = "ลองอีกครั้ง";
+"meditation.play" = "เล่นคำแนะนำ";
+"meditation.pause" = "หยุดชั่วคราว";
+"meditation.resume" = "ดำเนินต่อ";
+"meditation.stop" = "หยุด";
+"meditation.done" = "คำแนะนำเสร็จสิ้น";
+"meditation.close" = "ปิด";
+"meditation.try_this" = "การทำสมาธิแบบมีคำแนะนำ";
+"meditation.try_hint" = "สแกนร่างกายและแสดงภาพอารมณ์ ประมาณ 3 นาที";

--- a/Cathier/tr.lproj/Localizable.strings
+++ b/Cathier/tr.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Plaza sees emotion category and intensity only";
 "plaza.tier_emotions_desc" = "Plaza sees specific emotion words";
 "plaza.tier_full_desc" = "Plaza sees everything including notes";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Rehberli Meditasyon";
+"meditation.loading" = "Rehber metni oluşturuluyor…";
+"meditation.retry" = "Tekrar Dene";
+"meditation.play" = "Rehberi Oynat";
+"meditation.pause" = "Duraklat";
+"meditation.resume" = "Devam Et";
+"meditation.stop" = "Durdur";
+"meditation.done" = "Rehber Tamamlandı";
+"meditation.close" = "Kapat";
+"meditation.try_this" = "Rehberli meditasyon";
+"meditation.try_hint" = "Beden taraması ve duygu görselleştirmesi, ~3 dk";

--- a/Cathier/vi.lproj/Localizable.strings
+++ b/Cathier/vi.lproj/Localizable.strings
@@ -271,3 +271,16 @@
 "plaza.tier_category_desc" = "Quảng trường chỉ thấy danh mục và cường độ";
 "plaza.tier_emotions_desc" = "Quảng trường thấy từ cảm xúc cụ thể";
 "plaza.tier_full_desc" = "Quảng trường thấy tất cả, kể cả ghi chú";
+
+/* Guided Meditation */
+"meditation.nav_title" = "Thiền Có Hướng Dẫn";
+"meditation.loading" = "Đang tạo kịch bản hướng dẫn…";
+"meditation.retry" = "Thử lại";
+"meditation.play" = "Phát hướng dẫn";
+"meditation.pause" = "Tạm dừng";
+"meditation.resume" = "Tiếp tục";
+"meditation.stop" = "Dừng";
+"meditation.done" = "Hoàn thành hướng dẫn";
+"meditation.close" = "Đóng";
+"meditation.try_this" = "Thiền có hướng dẫn";
+"meditation.try_hint" = "Quét cơ thể và hình dung cảm xúc, ~3 phút";

--- a/Cathier/zh.lproj/Localizable.strings
+++ b/Cathier/zh.lproj/Localizable.strings
@@ -275,3 +275,16 @@
 "plaza.tier_category_desc" = "广场只看到情绪大类和强度";
 "plaza.tier_emotions_desc" = "广场看到具体情绪词";
 "plaza.tier_full_desc" = "广场看到全部内容含笔记";
+
+/* Guided Meditation */
+"meditation.nav_title" = "身体引导冥想";
+"meditation.loading" = "正在为你生成引导语…";
+"meditation.retry" = "再试一次";
+"meditation.play" = "播放引导";
+"meditation.pause" = "暂停";
+"meditation.resume" = "继续";
+"meditation.stop" = "结束";
+"meditation.done" = "引导完成";
+"meditation.close" = "关闭";
+"meditation.try_this" = "跟着引导语";
+"meditation.try_hint" = "身体扫描与情绪观想，约3分钟";


### PR DESCRIPTION
Closes #74.

Implementation pushed by claude-code-action but PR was not auto-created. Opening manually so build runs and auto-merge-claude.yml can squash this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)