### PR TITLE
@claude implement: 此刻的颜色从绿色改为橙色 (closes #75)

### DIFF
--- a/Cathier/ContentView.swift
+++ b/Cathier/ContentView.swift
@@ -6,7 +6,6 @@ struct ContentView: View {
     @State private var plazaVM = PlazaViewModel()
     @State private var selectedTab = 0
     @Environment(LanguageManager.self) private var lm
-    @Environment(ThemeManager.self) private var themeManager
 
     var body: some View {
         TabView(selection: $selectedTab) {
@@ -31,7 +30,7 @@ struct ContentView: View {
                     .onAppear { t("📱 SettingsView appeared") }
             }
         }
-        .tint(themeManager.accentColor)
+        .tint(.cathierAccent)
         .environment(friendVM)
         .environment(plazaVM)
         .task { await friendVM.initialize() }


### PR DESCRIPTION
Closes #75.

Implementation pushed by claude-code-action but PR was not auto-created. Opening manually so build runs and auto-merge-claude.yml can squash this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)