### PR TITLE
marketing: schedule at 06:00 Beijing + allow multiple runs/day

### DIFF
--- a/.github/workflows/marketing-daily.yml
+++ b/.github/workflows/marketing-daily.yml
@@ -2,8 +2,8 @@ name: Marketing Daily
 
 on:
   schedule:
-    # 01:00 UTC = 09:00 Asia/Shanghai
-    - cron: "0 1 * * *"
+    # 22:00 UTC = 06:00 Asia/Shanghai (next day)
+    - cron: "0 22 * * *"
   workflow_dispatch:
 
 jobs:
@@ -45,9 +45,9 @@ jobs:
           git config user.name "cathier-marketing-bot"
           git config user.email "marketing-bot@users.noreply.github.com"
 
-      - name: Get today's date
+      - name: Get today's date (Asia/Shanghai)
         id: date
-        run: echo "today=$(date +%F)" >> "$GITHUB_OUTPUT"
+        run: echo "today=$(TZ=Asia/Shanghai date +%F)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code orchestrator
         uses: anthropics/claude-code-action@v1
@@ -64,8 +64,8 @@ jobs:
             You have access to: OPENAI_API_KEY (env var), gh CLI, git, python3.
             Repository root is the working directory; import paths use the
             `marketing.publish.*` package.
-            Do NOT push if no commits were made. Do NOT open a duplicate issue
-            if one with label `marketing-ready` already exists for today.
+            Do NOT push if no commits were made. Multiple runs per day are
+            allowed — see the orchestrator's folder-naming rule for collisions.
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GH_TOKEN: ${{ secrets.FEEDBACK_PAT }}

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -6,11 +6,13 @@
 
 | 平台 | 频率 | 母语 | 工作流 |
 |---|---|---|---|
-| 小红书 | 每天 09:00 Asia/Shanghai | 中文 | `marketing-daily.yml` |
-| X | 每天 09:00 | 英文 | `marketing-daily.yml` |
-| Instagram | 每天 09:00 | 英文 | `marketing-daily.yml` |
-| Facebook | 每天 09:00 | 英文 | `marketing-daily.yml` |
+| 小红书 | 每天 06:00 Asia/Shanghai | 中文 | `marketing-daily.yml` |
+| X | 每天 06:00 | 英文 | `marketing-daily.yml` |
+| Instagram | 每天 06:00 | 英文 | `marketing-daily.yml` |
+| Facebook | 每天 06:00 | 英文 | `marketing-daily.yml` |
 | Reddit | 每周一 10:00 | 英文 | `marketing-weekly-reddit.yml` |
+
+同日多次运行（cron + 手动 dispatch，或多次 dispatch）允许并存：首跑落到 `posts/YYYY-MM-DD/`，再跑落到 `posts/YYYY-MM-DD-HHMM/`（北京时间），互不覆盖，每次都开独立 issue。
 
 ## 工作流
 
@@ -23,7 +25,7 @@
 ## Phase 1 人工部分
 
 打开 issue → body 是按平台分段的文案 + 图片相对路径 → 复制粘贴到对应 App 发。
-推荐发布顺序：xhs 立即（北京 9 点）→ instagram/facebook 中午（美东 9 点）→ x 晚上（美东 11 点）→ reddit 美东上午（周一）。
+推荐发布顺序：xhs 立即（北京 6 点）→ instagram/facebook 中午（美东 9 点）→ x 晚上（美东 11 点）→ reddit 美东上午（周一）。
 
 详见 `publish/xhs_checklist.md`。
 

--- a/marketing/prompts/daily-orchestrator.md
+++ b/marketing/prompts/daily-orchestrator.md
@@ -5,7 +5,10 @@
 ## 工作目录约定
 
 - 仓库根目录运行
-- 当日产出落到 `marketing/posts/{YYYY-MM-DD}/`（YYYY-MM-DD 由 `date +%F` 取）
+- 当日产出落到 `marketing/posts/{run-slug}/`，命名规则：
+  - 首选 `{YYYY-MM-DD}`（用 workflow 传进来的 today，已是 Asia/Shanghai 日期；如自己取就 `TZ=Asia/Shanghai date +%F`）
+  - 如该目录已存在（说明今天已经跑过一次），改用 `{YYYY-MM-DD}-{HHMM}`（由 `TZ=Asia/Shanghai date +%F-%H%M` 取，HHMM 也是北京时间）。允许同一天多份并存，不要覆盖
+  - 后续步骤里所有 `{YYYY-MM-DD}` 路径占位符都改成实际的 `{run-slug}`
 - 索引追加到 `marketing/posts/_index.jsonl`
 
 ## 流水线步骤
@@ -56,7 +59,7 @@ reddit 是另一条流水线（`reddit-orchestrator.md` + `marketing-weekly-redd
 - FAIL → 把"修改要求"塞回 post-draft 重写。最多 2 轮。
 - 第 3 轮仍 FAIL → 跳过该平台。所有平台都跳过 → 整体跳过当日，开 issue 标 `marketing-failed`，附编辑反馈，退出 0。
 
-通过的稿子写到 `marketing/posts/{YYYY-MM-DD}/{platform}.md`。
+通过的稿子写到 `marketing/posts/{run-slug}/{platform}.md`。
 
 ### 4. 出图
 
@@ -75,7 +78,7 @@ import os
 img = generate_image(
     prompt='<品牌前缀+场景>',
     size='1024x1536',
-    output_path=Path('marketing/posts/2026-05-07/xiaohongshu-1.png'),
+    output_path=Path('marketing/posts/{run-slug}/xiaohongshu-1.png'),  # 用实际 run-slug 替换
     api_key=os.environ['OPENAI_API_KEY'],
 )
 compose(
@@ -89,30 +92,32 @@ compose(
 
 ### 5. 索引追加
 
-为每个产出的 post 追加一行到 `marketing/posts/_index.jsonl`：
+为每个产出的 post 追加一行到 `marketing/posts/_index.jsonl`。`folder` 字段记录实际目录名，便于同日多次运行时区分：
 
 ```json
-{"date": "2026-05-07", "platform": "xhs", "angle_id": "instrument-serif-rationale", "status": "ready", "files": ["xiaohongshu.md", "xiaohongshu-1.png", ...]}
+{"date": "2026-05-07", "folder": "2026-05-07", "platform": "xhs", "angle_id": "instrument-serif-rationale", "status": "ready", "files": ["xiaohongshu.md", "xiaohongshu-1.png", ...]}
 ```
+
+如同日二次运行，`folder` 形如 `"2026-05-07-1430"`（UTC HHMM），`date` 仍为当天日期。`files` 路径相对于 `marketing/posts/{folder}/`。
 
 将所选 angle 在 `angles.json` 中的 `used_dates` 追加今日日期，`status` 仍为 "unused"（angle 可被复用，只是 14 天内不会被选）。
 
 ### 6. Commit
 
 ```bash
-git add marketing/posts/{YYYY-MM-DD}/ marketing/posts/_index.jsonl marketing/brain/angles.json
-git commit -m "marketing: daily content {YYYY-MM-DD} — {angle_id}"
+git add marketing/posts/{run-slug}/ marketing/posts/_index.jsonl marketing/brain/angles.json
+git commit -m "marketing: daily content {run-slug} — {angle_id}"
 git push
 ```
 
 ### 7. 通知
 
-通过 `gh` 开 GitHub Issue：
-- title: `marketing-ready: {YYYY-MM-DD} — {angle_id}`
+通过 `gh` 开 GitHub Issue（每次运行都开一个，不去重——同日多次跑就开多个 issue）：
+- title: `marketing-ready: {run-slug} — {angle_id}`
 - label: `marketing-ready`
-- body: 按平台分段（xhs / x / instagram / facebook 各一节），每节嵌入文案（代码块）+ 图片相对路径
+- body: 按平台分段（xhs / x / instagram / facebook 各一节），每节嵌入文案（代码块）+ 图片相对路径（路径里用实际的 run-slug）
 - body 顶部写一个"粘贴顺序"清单：先发哪个、后发哪个，例如：
-  - 立刻：xhs（北京时间 9 点）
+  - 立刻：xhs（北京时间 6 点）
   - 早 12 点（美东 9 点）：instagram、facebook
   - 晚 22 点（美东 11 点）：x
 


### PR DESCRIPTION
## Summary
- Cron 改到 22:00 UTC（北京次日 06:00），date 步骤用 TZ=Asia/Shanghai 让 {today} 是北京日期
- Orchestrator 支持当日多次运行：`posts/YYYY-MM-DD/` 已存在则落到 `posts/YYYY-MM-DD-HHMM/`（HHMM 北京时间），互不覆盖
- 每次运行都开独立 `marketing-ready` issue，不再去重
- `_index.jsonl` 新增 `folder` 字段记录实际目录名

## Test plan
- [ ] workflow_dispatch 一次跑得通（用今天 2026-05-08 测试）
- [ ] 同日二次手动触发，新内容落到 `posts/2026-05-08-HHMM/`，开第二个 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)