### PR TITLE
feat: add name field to FeedbackView with persistence

### DIFF
--- a/Cathier/Localization/Strings.swift
+++ b/Cathier/Localization/Strings.swift
@@ -196,6 +196,8 @@ extension LanguageManager {
     var journalEntryWriteHint: String        { localized("journal_entry.write_hint") }
 
     // MARK: FeedbackView
+    var feedbackNameLabel: String        { localized("feedback.name_label") }
+    var feedbackNamePlaceholder: String  { localized("feedback.name_placeholder") }
     var feedbackNavTitle: String         { localized("feedback.nav_title") }
     var feedbackSectionTitle: String     { localized("feedback.section_title") }
     var feedbackButton: String           { localized("feedback.button") }

--- a/Cathier/Services/GitHubService.swift
+++ b/Cathier/Services/GitHubService.swift
@@ -68,7 +68,7 @@ struct GitHubService {
         return downloadUrl
     }
 
-    static func createFeedbackIssue(title: String, body: String, images: [UIImage] = []) async throws -> URL {
+    static func createFeedbackIssue(title: String, body: String, images: [UIImage] = [], submittedBy: String = "") async throws -> URL {
         let resolvedToken = bundleToken
 
         var imageURLs: [String] = []
@@ -78,7 +78,7 @@ struct GitHubService {
             }
         }
 
-        var fullBody = body
+        var fullBody = submittedBy.isEmpty ? body : "**From:** \(submittedBy)\n\n\(body)"
         if !imageURLs.isEmpty {
             let imageMarkdown = imageURLs.enumerated()
                 .map { i, url in "![Screenshot \(i + 1)](\(url))" }

--- a/Cathier/Views/FeedbackView.swift
+++ b/Cathier/Views/FeedbackView.swift
@@ -5,6 +5,7 @@ struct FeedbackView: View {
     @Environment(LanguageManager.self) private var lm
     @Environment(\.dismiss) private var dismiss
 
+    @AppStorage("feedbackUserName") private var userName: String = ""
     @State private var title = ""
     @State private var bodyText = ""
     @State private var isSubmitting = false
@@ -16,6 +17,14 @@ struct FeedbackView: View {
     var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    TextField(lm.feedbackNamePlaceholder, text: $userName)
+                        .textInputAutocapitalization(.words)
+                        .autocorrectionDisabled()
+                } header: {
+                    Text(lm.feedbackNameLabel)
+                }
+
                 Section {
                     TextField(lm.feedbackTitlePlaceholder, text: $title)
                         .autocorrectionDisabled()
@@ -125,7 +134,8 @@ struct FeedbackView: View {
                             Text(lm.feedbackSubmit)
                         }
                     }
-                    .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty ||
+                    .disabled(userName.trimmingCharacters(in: .whitespaces).isEmpty ||
+                              title.trimmingCharacters(in: .whitespaces).isEmpty ||
                               bodyText.trimmingCharacters(in: .whitespaces).isEmpty ||
                               isSubmitting)
                 }
@@ -138,6 +148,7 @@ struct FeedbackView: View {
         errorMessage = nil
         let trimmedTitle = title.trimmingCharacters(in: .whitespaces)
         let trimmedBody = bodyText.trimmingCharacters(in: .whitespaces)
+        let trimmedName = userName.trimmingCharacters(in: .whitespaces)
         let images = attachedImages
 
         Task {
@@ -145,7 +156,8 @@ struct FeedbackView: View {
                 let url = try await GitHubService.createFeedbackIssue(
                     title: trimmedTitle,
                     body: trimmedBody,
-                    images: images
+                    images: images,
+                    submittedBy: trimmedName
                 )
                 await MainActor.run {
                     submittedURL = url

--- a/Cathier/ar.lproj/Localizable.strings
+++ b/Cathier/ar.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "مرة واحدة في اليوم \u2014 اترك أثراً لليوم";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "اقتراحات الميزات";
 "feedback.section_title" = "ملاحظات";
 "feedback.button" = "إرسال اقتراح";

--- a/Cathier/de.lproj/Localizable.strings
+++ b/Cathier/de.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Einmal täglich \u2014 hinterlasse eine Spur für heute";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Funktionsvorschläge";
 "feedback.section_title" = "Feedback";
 "feedback.button" = "Vorschlag einreichen";

--- a/Cathier/en.lproj/Localizable.strings
+++ b/Cathier/en.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "journal_entry.write_hint" = "Once a day \u2014 leave a mark for today";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Feature Feedback";
 "feedback.section_title" = "Feedback";
 "feedback.button" = "Submit Feedback";

--- a/Cathier/es.lproj/Localizable.strings
+++ b/Cathier/es.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Una vez al día \u2014 deja una huella para hoy";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Sugerencias de funciones";
 "feedback.section_title" = "Comentarios";
 "feedback.button" = "Enviar sugerencia";

--- a/Cathier/fr.lproj/Localizable.strings
+++ b/Cathier/fr.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Une fois par jour \u2014 laissez une trace pour aujourd'hui";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Suggestions de fonctionnalités";
 "feedback.section_title" = "Retour";
 "feedback.button" = "Soumettre une suggestion";

--- a/Cathier/hi.lproj/Localizable.strings
+++ b/Cathier/hi.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "दिन में एक बार \u2014 आज के लिए एक निशान छोड़ें";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "फीचर सुझाव";
 "feedback.section_title" = "फीडबैक";
 "feedback.button" = "सुझाव सबमिट करें";

--- a/Cathier/it.lproj/Localizable.strings
+++ b/Cathier/it.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Una volta al giorno \u2014 lascia un segno per oggi";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Suggerimenti funzionalità";
 "feedback.section_title" = "Feedback";
 "feedback.button" = "Invia suggerimento";

--- a/Cathier/ja.lproj/Localizable.strings
+++ b/Cathier/ja.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "journal_entry.write_hint" = "1日1回、今日の足跡を残しましょう";
 
 /* FeedbackView */
+"feedback.name_label" = "お名前";
+"feedback.name_placeholder" = "お名前";
 "feedback.nav_title" = "機能フィードバック";
 "feedback.section_title" = "フィードバック";
 "feedback.button" = "フィードバックを送る";

--- a/Cathier/ko.lproj/Localizable.strings
+++ b/Cathier/ko.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "하루에 한 번 \u2014 오늘을 위한 흔적을 남겨요";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "기능 제안";
 "feedback.section_title" = "피드백";
 "feedback.button" = "제안 제출";

--- a/Cathier/pt.lproj/Localizable.strings
+++ b/Cathier/pt.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Uma vez por dia \u2014 deixe uma marca para hoje";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Sugestões de recursos";
 "feedback.section_title" = "Feedback";
 "feedback.button" = "Enviar sugestão";

--- a/Cathier/ru.lproj/Localizable.strings
+++ b/Cathier/ru.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Один раз в день \u2014 оставьте след сегодняшнего дня";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Предложения по функциям";
 "feedback.section_title" = "Отзыв";
 "feedback.button" = "Отправить предложение";

--- a/Cathier/th.lproj/Localizable.strings
+++ b/Cathier/th.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "วันละครั้ง \u2014 ทิ้งรอยไว้สำหรับวันนี้";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "ข้อเสนอแนะฟีเจอร์";
 "feedback.section_title" = "ข้อเสนอแนะ";
 "feedback.button" = "ส่งข้อเสนอแนะ";

--- a/Cathier/tr.lproj/Localizable.strings
+++ b/Cathier/tr.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Günde bir kez \u2014 bugün için bir iz bırak";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Özellik Önerileri";
 "feedback.section_title" = "Geri Bildirim";
 "feedback.button" = "Öneri Gönder";

--- a/Cathier/vi.lproj/Localizable.strings
+++ b/Cathier/vi.lproj/Localizable.strings
@@ -191,6 +191,8 @@
 "journal_entry.write_hint" = "Một lần mỗi ngày \u2014 để lại dấu ấn cho hôm nay";
 
 /* FeedbackView */
+"feedback.name_label" = "Name";
+"feedback.name_placeholder" = "Your name";
 "feedback.nav_title" = "Đề xuất tính năng";
 "feedback.section_title" = "Phản hồi";
 "feedback.button" = "Gửi đề xuất";

--- a/Cathier/zh.lproj/Localizable.strings
+++ b/Cathier/zh.lproj/Localizable.strings
@@ -193,6 +193,8 @@
 "journal_entry.write_hint" = "每天一次，留下属于今天的印记";
 
 /* FeedbackView */
+"feedback.name_label" = "姓名";
+"feedback.name_placeholder" = "你的姓名";
 "feedback.nav_title" = "功能建议";
 "feedback.section_title" = "反馈与建议";
 "feedback.button" = "提交功能建议";


### PR DESCRIPTION
Closes #83.

Implements user-requested name field in the feedback form, with persistence across submissions and "From: \<name\>" attribution.

This PR was already pushed as a branch on 2026-05-06 but no PR was opened (auto-PR step in the feedback loop appears to have skipped). Reopening manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)