### PR TITLE
feat: add body-state music recommendation (来自身体的音乐)

### DIFF
--- a/Cathier/Services/ClaudeService.swift
+++ b/Cathier/Services/ClaudeService.swift
@@ -41,6 +41,26 @@ struct StructuredFeedback: Codable {
     }
 }
 
+struct MusicRecommendation: Codable {
+    var mood: String
+    var description: String
+    var genres: [String]
+    var searchQuery: String
+
+    static func parse(_ text: String) -> MusicRecommendation? {
+        var jsonText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if jsonText.hasPrefix("```") {
+            let lines = jsonText.components(separatedBy: "\n")
+            let inner = lines.dropFirst().prefix(while: { !$0.hasPrefix("```") })
+            jsonText = inner.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard let data = jsonText.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(MusicRecommendation.self, from: data)
+        else { return nil }
+        return decoded
+    }
+}
+
 // Anthropic wire format
 private struct ClaudeResponse: Decodable {
     let content: [ContentBlock]
@@ -1278,5 +1298,82 @@ enum ClaudeService {
         if punchline.isEmpty, lines.count >= 2 { punchline = lines[1] }
 
         return (question, punchline)
+    }
+
+    // MARK: - Body Music Recommendation
+
+    static func generateMusicRecommendation(
+        bodyParts: [String],
+        sensations: [String],
+        intensity: Int,
+        emotions: [String],
+        language: AppLanguage = LanguageManager.shared.currentLanguage
+    ) async throws -> MusicRecommendation {
+        let lm = LanguageManager.shared
+        let parsed = parseBodySensations(sensations)
+
+        let system: String
+        let user: String
+
+        switch language {
+        case .zh:
+            system = """
+            你是「觉察」（Cathier）App 的身心音乐顾问。用户刚完成了一次身体扫描，你需要根据他们的身体状态推荐一段最适合此刻的音乐。
+
+            你的回应必须是以下格式的合法 JSON，不加任何说明文字或代码块：
+            {"mood":"用2-4个词描述此刻适合的音乐情绪（如：舒缓、内省、有力量的）","description":"用2-3句话解释为什么这种音乐适合用户此刻的身心状态，语气温暖，像一位懂音乐的朋友","genres":["推荐的音乐风格1","推荐的音乐风格2"],"searchQuery":"适合在流媒体平台搜索的英文关键词，3-5个词"}
+
+            推荐原则：
+            - 高强度（7-10）→ 考虑有结构感的音乐（neo-classical, minimal techno, drone）
+            - 中强度（4-6）→ 考虑流动感的音乐（ambient, lo-fi, indie folk）
+            - 低强度（1-3）→ 考虑轻盈或空灵的音乐（minimalism, nature sounds, soft jazz）
+            - 胸口紧绷、压迫感 → 避免快节奏，选择缓慢展开的音乐
+            - 情绪积极 → 可以稍微明亮有活力
+            - 情绪低落/悲伤 → 选择陪伴而非强行振奋的音乐
+            """
+            let partsStr = bodyParts.isEmpty ? "未指定" : bodyParts.joined(separator: "、")
+            let emosStr = emotions.isEmpty ? "未标记" : emotions.joined(separator: "、")
+            var sensesStr = ""
+            if !parsed.perPart.isEmpty {
+                sensesStr = parsed.perPart.map { "\($0.part)：\($0.sensations.joined(separator: "、"))" }.joined(separator: "；")
+            }
+            user = "身体部位：\(partsStr)\n感受：\(sensesStr.isEmpty ? "未指定" : sensesStr)\n情绪：\(emosStr)\n强度：\(intensity)/10\n\n请为我推荐此刻最适合的音乐。"
+
+        case .ja:
+            system = """
+            あなたはCathier（覚察）アプリの心身音楽アドバイザーです。ユーザーはボディスキャンを完了しました。身体状態に最も合った音楽を推薦してください。
+
+            以下の形式の有効なJSONのみを出力してください：
+            {"mood":"今この瞬間に合う音楽の雰囲気を2〜4語で（例：穏やか、内省的、力強い）","description":"この音楽がユーザーの今の心身状態に合う理由を2〜3文で、温かい友人のような口調で","genres":["推薦ジャンル1","推薦ジャンル2"],"searchQuery":"ストリーミングサービスで検索するための英語キーワード3〜5語"}
+            """
+            let partsStr = bodyParts.map { lm.display($0) }.joined(separator: "、")
+            let emosStr = emotions.map { lm.display($0) }.joined(separator: "、")
+            user = "身体部位：\(partsStr.isEmpty ? "未指定" : partsStr)\n感情：\(emosStr.isEmpty ? "不明" : emosStr)\n強度：\(intensity)/10\n\n今この瞬間に最も合った音楽を推薦してください。"
+
+        default:
+            system = """
+            You are the mind-body music advisor for Cathier — an emotion perception training app. The user just completed a body scan. Recommend music that best matches their current physical and emotional state.
+
+            Your response must be valid JSON only, with no additional text or code blocks:
+            {"mood":"2-4 words describing the ideal music mood for this moment (e.g. calm, introspective, grounding)","description":"2-3 sentences explaining why this music fits the user's current body-mind state, warm and personal tone","genres":["recommended genre 1","recommended genre 2"],"searchQuery":"3-5 English keywords suitable for searching on a streaming platform"}
+
+            Matching principles:
+            - High intensity (7-10) → structured, anchoring music (neo-classical, minimal techno, drone)
+            - Mid intensity (4-6) → flowing music (ambient, lo-fi, indie folk)
+            - Low intensity (1-3) → light or ethereal music (minimalism, nature sounds, soft jazz)
+            - Chest tightness / pressure → avoid fast rhythms, choose slowly unfolding music
+            - Positive emotions → can be slightly brighter and more energetic
+            - Sadness / low mood → companionable music, not forcibly uplifting
+            """
+            let partsStr = bodyParts.map { lm.display($0) }.joined(separator: ", ")
+            let emosStr = emotions.map { lm.display($0) }.joined(separator: ", ")
+            user = "Body areas: \(partsStr.isEmpty ? "unspecified" : partsStr)\nEmotions: \(emosStr.isEmpty ? "unlabeled" : emosStr)\nIntensity: \(intensity)/10\n\nPlease recommend the most suitable music for this moment."
+        }
+
+        let raw = try await call(model: feedbackModel, system: system, user: user, maxTokens: 800)
+        guard let recommendation = MusicRecommendation.parse(raw) else {
+            throw ClaudeError.decodingError
+        }
+        return recommendation
     }
 }

--- a/Cathier/Views/BodyMusicView.swift
+++ b/Cathier/Views/BodyMusicView.swift
@@ -1,0 +1,322 @@
+import SwiftUI
+
+struct BodyMusicView: View {
+    let bodyParts: [String]
+    let sensations: [String]
+    let intensity: Int
+    let emotions: [String]
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(LanguageManager.self) private var lm
+
+    @State private var recommendation: MusicRecommendation?
+    @State private var isLoading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    if isLoading {
+                        loadingView
+                    } else if let error = errorMessage {
+                        errorView(error)
+                    } else if let rec = recommendation {
+                        recommendationContent(rec)
+                    }
+                }
+                .padding(20)
+            }
+            .background(Color.cathierBackground)
+            .navigationTitle(navTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .task { await loadRecommendation() }
+    }
+
+    // MARK: - Nav title
+
+    private var navTitle: String {
+        switch lm.currentLanguage {
+        case .zh: return "来自身体的音乐"
+        case .ja: return "身体からの音楽"
+        default:  return "Music from the Body"
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.4)
+                .tint(.cathierAccent)
+            Text(loadingHint)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+
+    private var loadingHint: String {
+        switch lm.currentLanguage {
+        case .zh: return "正在感知你的身体，寻找适合的音乐…"
+        case .ja: return "あなたの身体を感じて、音楽を探しています…"
+        default:  return "Sensing your body state, finding the right music…"
+        }
+    }
+
+    // MARK: - Error
+
+    private func errorView(_ message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 36))
+                .foregroundColor(.cathierAccent)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            Button(retryLabel) {
+                Task { await loadRecommendation() }
+            }
+            .foregroundColor(.cathierAccent)
+        }
+        .padding(.vertical, 40)
+    }
+
+    private var retryLabel: String {
+        switch lm.currentLanguage {
+        case .zh: return "重试"
+        case .ja: return "再試行"
+        default:  return "Retry"
+        }
+    }
+
+    // MARK: - Recommendation content
+
+    private func recommendationContent(_ rec: MusicRecommendation) -> some View {
+        VStack(spacing: 20) {
+            // Body state summary
+            bodyStateSummaryCard
+
+            // Mood header
+            moodHeader(rec.mood)
+
+            // AI description card (Instrument Serif — journal moment)
+            descriptionCard(rec.description)
+
+            // Genre chips
+            if !rec.genres.isEmpty {
+                genreChips(rec.genres)
+            }
+
+            // Open in music app
+            if !rec.searchQuery.isEmpty {
+                musicSearchButton(rec.searchQuery)
+            }
+        }
+    }
+
+    private var bodyStateSummaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            let summaryLabel: String
+            switch lm.currentLanguage {
+            case .zh: summaryLabel = "当前身体状态"
+            case .ja: summaryLabel = "現在の身体状態"
+            default:  summaryLabel = "Current Body State"
+            }
+            Text(summaryLabel)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(.cathierAccent)
+                .tracking(0.5)
+                .textCase(.uppercase)
+
+            let parts = bodyParts.prefix(4).joined(separator: lm.currentLanguage == .en ? ", " : "、")
+            let emos  = emotions.prefix(3).joined(separator: lm.currentLanguage == .en ? ", " : "、")
+
+            if !parts.isEmpty {
+                Label(parts, systemImage: "figure.stand")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            if !emos.isEmpty {
+                Label(emos, systemImage: "heart")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            let intensityLabel: String
+            switch lm.currentLanguage {
+            case .zh: intensityLabel = "强度 \(intensity)/10"
+            case .ja: intensityLabel = "強度 \(intensity)/10"
+            default:  intensityLabel = "Intensity \(intensity)/10"
+            }
+            Label(intensityLabel, systemImage: "waveform.path.ecg")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.cathierSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.cathierAccent.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private func moodHeader(_ mood: String) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "music.note")
+                .font(.title3)
+                .foregroundColor(.cathierAccent)
+            Text(mood)
+                .font(.title3)
+                .fontWeight(.semibold)
+                .foregroundColor(.primary)
+            Spacer()
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private func descriptionCard(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.cathierAccent)
+                    .frame(width: 6, height: 6)
+                Text("Cathier")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.cathierAccent)
+                    .tracking(0.08)
+                    .textCase(.uppercase)
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color.cathierAccentLight)
+
+            Text(text)
+                .font(.cathierSerif(.body))
+                .lineSpacing(6)
+                .foregroundColor(.primary)
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.cathierAccent.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private func genreChips(_ genres: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            let genreLabel: String
+            switch lm.currentLanguage {
+            case .zh: genreLabel = "推荐风格"
+            case .ja: genreLabel = "推薦ジャンル"
+            default:  genreLabel = "Recommended Genres"
+            }
+            Text(genreLabel)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(.secondary)
+                .tracking(0.5)
+                .textCase(.uppercase)
+
+            FlowLayout(spacing: 8) {
+                ForEach(genres, id: \.self) { genre in
+                    Text(genre)
+                        .font(.subheadline)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(Color.cathierAccentLight)
+                        .foregroundColor(.cathierAccent)
+                        .clipShape(Capsule())
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func musicSearchButton(_ query: String) -> some View {
+        VStack(spacing: 10) {
+            Button(action: { openAppleMusic(query: query) }) {
+                HStack(spacing: 10) {
+                    Image(systemName: "music.note.list")
+                        .font(.body)
+                    Text(appleMusicLabel)
+                        .font(.headline)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.cathierAccent)
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+
+            Text(searchQueryHint(query))
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var appleMusicLabel: String {
+        switch lm.currentLanguage {
+        case .zh: return "在 Apple Music 中搜索"
+        case .ja: return "Apple Musicで検索"
+        default:  return "Search on Apple Music"
+        }
+    }
+
+    private func searchQueryHint(_ query: String) -> String {
+        switch lm.currentLanguage {
+        case .zh: return "搜索词：\(query)"
+        case .ja: return "検索ワード：\(query)"
+        default:  return "Search: \(query)"
+        }
+    }
+
+    private func openAppleMusic(query: String) {
+        guard let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+        let urlString = "music://music.apple.com/search?term=\(encoded)"
+        if let url = URL(string: urlString), UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        } else if let webURL = URL(string: "https://music.apple.com/us/search?term=\(encoded)") {
+            UIApplication.shared.open(webURL)
+        }
+    }
+
+    // MARK: - Load
+
+    private func loadRecommendation() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            recommendation = try await ClaudeService.generateMusicRecommendation(
+                bodyParts: bodyParts,
+                sensations: sensations,
+                intensity: intensity,
+                emotions: emotions,
+                language: lm.currentLanguage
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/Cathier/Views/TodayView.swift
+++ b/Cathier/Views/TodayView.swift
@@ -14,6 +14,7 @@ struct TodayView: View {
     @AppStorage("lastCelebratedStreakMilestone") private var lastCelebratedStreakMilestone: Int = 0
     @AppStorage("personalBestStreak") private var personalBestStreak: Int = 0
     @State private var showingHealth = false
+    @State private var showingMusic = false
     @State private var dismissedMilestone: Int = 0
     @Environment(LanguageManager.self) private var lm
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -135,6 +136,10 @@ struct TodayView: View {
                     healthSection
                         .padding(.horizontal, 20)
 
+                    // Body music entry
+                    musicSection
+                        .padding(.horizontal, 20)
+
                     Spacer(minLength: 40)
                 }
                 .padding(.top, 8)
@@ -182,6 +187,17 @@ struct TodayView: View {
             .sheet(isPresented: $showingHealth) {
                 HealthInsightView()
                     .environment(lm)
+            }
+            .sheet(isPresented: $showingMusic) {
+                if let recent = checkIns.first {
+                    BodyMusicView(
+                        bodyParts: recent.bodyParts,
+                        sensations: recent.sensations,
+                        intensity: recent.intensity,
+                        emotions: recent.emotions
+                    )
+                    .environment(lm)
+                }
             }
         }
     }
@@ -438,6 +454,74 @@ struct TodayView: View {
                             .font(.subheadline)
                             .fontWeight(.semibold)
                             .foregroundColor(.primary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(16)
+                .background(Color.cathierSurface)
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Music Section
+
+    private var musicSection: some View {
+        let title: String
+        let hint: String
+        switch lm.currentLanguage {
+        case .zh:
+            title = "来自身体的音乐"
+            hint = checkIns.isEmpty
+                ? "完成一次身体扫描，获得专属音乐推荐"
+                : "根据你刚才的身体状态，AI 为你寻找适合的音乐"
+        case .ja:
+            title = "身体からの音楽"
+            hint = checkIns.isEmpty
+                ? "ボディスキャンを完了して、パーソナライズされた音楽をもらおう"
+                : "あなたの身体状態に合わせて、AIが最適な音楽を提案します"
+        default:
+            title = "Music from the Body"
+            hint = checkIns.isEmpty
+                ? "Complete a body scan to get personalized music recommendations"
+                : "AI finds music that matches your current body state"
+        }
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+
+            Button(action: {
+                if !checkIns.isEmpty { showingMusic = true }
+                else { showingCheckIn = true }
+            }) {
+                HStack(spacing: 14) {
+                    ZStack {
+                        Circle()
+                            .fill(Color.cathierAccent.opacity(0.15))
+                            .frame(width: 48, height: 48)
+                        Image(systemName: "music.note")
+                            .font(.system(size: 20))
+                            .foregroundColor(Color.cathierAccent)
+                    }
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(hint)
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.primary)
+                        if let recent = checkIns.first, !recent.emotions.isEmpty {
+                            let preview = recent.emotions.prefix(3).joined(
+                                separator: lm.currentLanguage == .en ? ", " : "、"
+                            )
+                            Text(preview)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
                     }
                     Spacer()
                     Image(systemName: "chevron.right")


### PR DESCRIPTION
Closes #88.

Implements the user-requested feature: after a body scan, recommend music based on the body state.

Branch was pushed on 2026-05-07 but no PR was opened. Reopening manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)