### PR TITLE
fix(BodyMusicView): hoist localized labels out of @ViewBuilder body

### DIFF
--- a/Cathier/Views/BodyMusicView.swift
+++ b/Cathier/Views/BodyMusicView.swift
@@ -128,22 +128,35 @@ struct BodyMusicView: View {
     }
 
     private var bodyStateSummaryCard: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            let summaryLabel: String
+        // @ViewBuilder bodies treat statements as views, so a `switch` used
+        // imperatively (assigning to a `let`) evaluates to `()` and fails to
+        // conform to View. Compute the localized strings outside the
+        // ViewBuilder body so the switches are statement-position, not
+        // view-position.
+        let summaryLabel: String = {
             switch lm.currentLanguage {
-            case .zh: summaryLabel = "当前身体状态"
-            case .ja: summaryLabel = "現在の身体状態"
-            default:  summaryLabel = "Current Body State"
+            case .zh: return "当前身体状态"
+            case .ja: return "現在の身体状態"
+            default:  return "Current Body State"
             }
+        }()
+        let intensityLabel: String = {
+            switch lm.currentLanguage {
+            case .zh: return "强度 \(intensity)/10"
+            case .ja: return "強度 \(intensity)/10"
+            default:  return "Intensity \(intensity)/10"
+            }
+        }()
+        let parts = bodyParts.prefix(4).joined(separator: lm.currentLanguage == .en ? ", " : "、")
+        let emos  = emotions.prefix(3).joined(separator: lm.currentLanguage == .en ? ", " : "、")
+
+        return VStack(alignment: .leading, spacing: 8) {
             Text(summaryLabel)
                 .font(.caption)
                 .fontWeight(.semibold)
                 .foregroundColor(.cathierAccent)
                 .tracking(0.5)
                 .textCase(.uppercase)
-
-            let parts = bodyParts.prefix(4).joined(separator: lm.currentLanguage == .en ? ", " : "、")
-            let emos  = emotions.prefix(3).joined(separator: lm.currentLanguage == .en ? ", " : "、")
 
             if !parts.isEmpty {
                 Label(parts, systemImage: "figure.stand")
@@ -156,12 +169,6 @@ struct BodyMusicView: View {
                     .foregroundColor(.secondary)
             }
 
-            let intensityLabel: String
-            switch lm.currentLanguage {
-            case .zh: intensityLabel = "强度 \(intensity)/10"
-            case .ja: intensityLabel = "強度 \(intensity)/10"
-            default:  intensityLabel = "Intensity \(intensity)/10"
-            }
             Label(intensityLabel, systemImage: "waveform.path.ecg")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
@@ -223,13 +230,14 @@ struct BodyMusicView: View {
     }
 
     private func genreChips(_ genres: [String]) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            let genreLabel: String
+        let genreLabel: String = {
             switch lm.currentLanguage {
-            case .zh: genreLabel = "推荐风格"
-            case .ja: genreLabel = "推薦ジャンル"
-            default:  genreLabel = "Recommended Genres"
+            case .zh: return "推荐风格"
+            case .ja: return "推薦ジャンル"
+            default:  return "Recommended Genres"
             }
+        }()
+        return VStack(alignment: .leading, spacing: 8) {
             Text(genreLabel)
                 .font(.caption)
                 .fontWeight(.semibold)


### PR DESCRIPTION
## Why \`main\` is broken

PR #111 (body-state music) introduced two compile errors in \`BodyMusicView.swift\`:

\`\`\`
::error file=BodyMusicView.swift,line=134,col=23::type '()' cannot conform to 'View'
::error file=BodyMusicView.swift,line=229,col=23::type '()' cannot conform to 'View'
\`\`\`

Every push to \`main\` since 2026-05-11 14:50 has failed \`Build & Deploy\`. No new TestFlight builds will go up (latest tag still \`testflight/562\`).

## Root cause

Three places in the file used this pattern inside a \`@ViewBuilder\` body:

\`\`\`swift
VStack { 
    let label: String
    switch lm.currentLanguage {
    case .zh: label = "..."
    case .ja: label = "..."
    default:  label = "..."
    }
    Text(label) ...
}
\`\`\`

\`@ViewBuilder\` treats statements as views. A \`switch\` used imperatively (assigning to a \`let\`) evaluates to \`()\` (Void), which the builder then tries to coerce into a \`View\` — the error.

## Fix

Hoist each localized String out of the \`@ViewBuilder\` body using a self-invoking closure, then \`return VStack { ... }\` with the precomputed values. The switch is now in statement-position where \`return\` works.

This matches the existing pattern used by \`navTitle\`, \`loadingHint\`, \`retryLabel\`, and \`appleMusicLabel\` elsewhere in the file — they're computed-property bodies. The new ones need to coexist with View statements in a VStack, so a closure is the minimal-diff equivalent.

## Test plan

- [ ] CI \`Build & Deploy\` (pull_request) passes
- [ ] After merge, the push to main triggers \`Build & Deploy\` → \`testflight/563\` appears
- [ ] Body-state music sheet still renders correctly in app (zh / ja / en labels show correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)