### PR TITLE
feat: add GitHub link below feedback form (closes #94)

### DIFF
--- a/Cathier/Localization/Strings.swift
+++ b/Cathier/Localization/Strings.swift
@@ -225,6 +225,7 @@ extension LanguageManager {
     var feedbackSubmit: String              { localized("feedback.submit") }
     var feedbackSuccess: String             { localized("feedback.success") }
     var feedbackViewIssue: String           { localized("feedback.view_issue") }
+    var feedbackViewAllIssues: String        { localized("feedback.view_all_issues") }
     var feedbackScreenshotLabel: String     { localized("feedback.screenshot_label") }
     var feedbackScreenshotAdd: String       { localized("feedback.screenshot_add") }
     var feedbackScreenshotFooter: String    { localized("feedback.screenshot_footer") }

--- a/Cathier/Views/FeedbackView.swift
+++ b/Cathier/Views/FeedbackView.swift
@@ -38,8 +38,13 @@ struct FeedbackView: View {
                 } header: {
                     Text(lm.feedbackBodyLabel)
                 } footer: {
-                    Text(lm.feedbackBodyFooter)
-                        .font(.caption)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(lm.feedbackBodyFooter)
+                        Link(lm.feedbackViewAllIssues,
+                             destination: URL(string: "https://github.com/jianshuo/Cathier/issues")!)
+                            .foregroundColor(.cathierAccent)
+                    }
+                    .font(.caption)
                 }
 
                 Section {

--- a/Cathier/ar.lproj/Localizable.strings
+++ b/Cathier/ar.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "إعدادات GitHub";
 "feedback.token_footer" = "يلزم رمز الوصول الشخصي GitHub بنطاق 'repo' لإرسال المشكلات. مخزَّن محلياً فقط.";
 "feedback.submit" = "إرسال";
+"feedback.view_all_issues" = "انظر اقتراحات الآخرين →";
 "feedback.screenshot_label" = "لقطات الشاشة";
 "feedback.screenshot_add" = "إضافة لقطة شاشة";
 "feedback.screenshot_footer" = "أرفق ما يصل إلى 3 لقطات شاشة (اختياري).";

--- a/Cathier/de.lproj/Localizable.strings
+++ b/Cathier/de.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "feedback.submit" = "Einreichen";
 "feedback.success" = "Erfolgreich eingereicht!";
 "feedback.view_issue" = "GitHub Issue ansehen \u2192";
+"feedback.view_all_issues" = "Vorschläge anderer ansehen →";
 "feedback.screenshot_label" = "Screenshots";
 "feedback.screenshot_add" = "Screenshot hinzuf\u00fcgen";
 "feedback.screenshot_footer" = "Bis zu 3 Screenshots anh\u00e4ngen (optional).";

--- a/Cathier/en.lproj/Localizable.strings
+++ b/Cathier/en.lproj/Localizable.strings
@@ -209,6 +209,7 @@
 "feedback.submit" = "Submit";
 "feedback.success" = "Submitted successfully!";
 "feedback.view_issue" = "View GitHub Issue \u2192";
+"feedback.view_all_issues" = "See what others have suggested →";
 "feedback.screenshot_label" = "Screenshots";
 "feedback.screenshot_add" = "Add Screenshot";
 "feedback.screenshot_footer" = "Attach up to 3 screenshots (optional).";

--- a/Cathier/es.lproj/Localizable.strings
+++ b/Cathier/es.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "feedback.submit" = "Enviar";
 "feedback.success" = "¡Enviado con éxito!";
 "feedback.view_issue" = "Ver Issue de GitHub \u2192";
+"feedback.view_all_issues" = "Ver las sugerencias de otros →";
 "feedback.screenshot_label" = "Capturas de pantalla";
 "feedback.screenshot_add" = "A\u00f1adir captura";
 "feedback.screenshot_footer" = "Adjunta hasta 3 capturas de pantalla (opcional).";

--- a/Cathier/fr.lproj/Localizable.strings
+++ b/Cathier/fr.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "feedback.submit" = "Soumettre";
 "feedback.success" = "Soumis avec succès !";
 "feedback.view_issue" = "Voir l'Issue GitHub \u2192";
+"feedback.view_all_issues" = "Voir les suggestions des autres \u2192";
 "feedback.screenshot_label" = "Captures d'\u00e9cran";
 "feedback.screenshot_add" = "Ajouter une capture";
 "feedback.screenshot_footer" = "Joindre jusqu'\u00e0 3 captures d'\u00e9cran (optionnel).";

--- a/Cathier/hi.lproj/Localizable.strings
+++ b/Cathier/hi.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "GitHub सेटिंग्स";
 "feedback.token_footer" = "Issues सबमिट करने के लिए 'repo' स्कोप वाला GitHub Personal Access Token आवश्यक है। केवल स्थानीय रूप से संग्रहीत।";
 "feedback.submit" = "सबमिट करें";
+"feedback.view_all_issues" = "दूसरों के सुझाव देखें →";
 "feedback.screenshot_label" = "स्क्रीनशॉट";
 "feedback.screenshot_add" = "स्क्रीनशॉट जोड़ें";
 "feedback.screenshot_footer" = "अधिकतम 3 स्क्रीनशॉट संलग्न करें (वैकल्पिक)।";

--- a/Cathier/it.lproj/Localizable.strings
+++ b/Cathier/it.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "feedback.submit" = "Invia";
 "feedback.success" = "Inviato con successo!";
 "feedback.view_issue" = "Visualizza Issue GitHub \u2192";
+"feedback.view_all_issues" = "Vedere i suggerimenti degli altri →";
 "feedback.screenshot_label" = "Screenshot";
 "feedback.screenshot_add" = "Aggiungi screenshot";
 "feedback.screenshot_footer" = "Allega fino a 3 screenshot (opzionale).";

--- a/Cathier/ja.lproj/Localizable.strings
+++ b/Cathier/ja.lproj/Localizable.strings
@@ -209,6 +209,7 @@
 "feedback.submit" = "送信";
 "feedback.success" = "送信成功！";
 "feedback.view_issue" = "GitHub Issueを見る →";
+"feedback.view_all_issues" = "他の人が提案した内容を見る →";
 "feedback.screenshot_label" = "スクリーンショット";
 "feedback.screenshot_add" = "スクリーンショットを追加";
 "feedback.screenshot_footer" = "最大3枚のスクリーンショットを添付できます（任意）。";

--- a/Cathier/ko.lproj/Localizable.strings
+++ b/Cathier/ko.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "GitHub 설정";
 "feedback.token_footer" = "이슈 제출을 위해 'repo' 범위의 GitHub 개인 액세스 토큰이 필요합니다. 로컬에만 저장됩니다.";
 "feedback.submit" = "제출";
+"feedback.view_all_issues" = "다른 사람들의 제안 보기 →";
 "feedback.screenshot_label" = "스크린샷";
 "feedback.screenshot_add" = "스크린샷 추가";
 "feedback.screenshot_footer" = "스크린샷을 최대 3장 첨부할 수 있습니다 (선택 사항).";

--- a/Cathier/pt.lproj/Localizable.strings
+++ b/Cathier/pt.lproj/Localizable.strings
@@ -207,6 +207,7 @@
 "feedback.submit" = "Enviar";
 "feedback.success" = "Enviado com sucesso!";
 "feedback.view_issue" = "Ver Issue do GitHub \u2192";
+"feedback.view_all_issues" = "Ver sugestões dos outros →";
 "feedback.screenshot_label" = "Capturas de tela";
 "feedback.screenshot_add" = "Adicionar captura";
 "feedback.screenshot_footer" = "Anexe at\u00e9 3 capturas de tela (opcional).";

--- a/Cathier/ru.lproj/Localizable.strings
+++ b/Cathier/ru.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "Настройки GitHub";
 "feedback.token_footer" = "Для отправки issues требуется личный токен доступа GitHub с областью 'repo'. Хранится только локально.";
 "feedback.submit" = "Отправить";
+"feedback.view_all_issues" = "Посмотреть предложения других →";
 "feedback.screenshot_label" = "Снимки экрана";
 "feedback.screenshot_add" = "Добавить снимок";
 "feedback.screenshot_footer" = "Прикрепите до 3 снимков экрана (необязательно).";

--- a/Cathier/th.lproj/Localizable.strings
+++ b/Cathier/th.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "การตั้งค่า GitHub";
 "feedback.token_footer" = "ต้องใช้ GitHub Personal Access Token ที่มีขอบเขต 'repo' เพื่อส่ง Issues จัดเก็บในเครื่องเท่านั้น";
 "feedback.submit" = "ส่ง";
+"feedback.view_all_issues" = "ดูข้อเสนอแนะของผู้อื่น →";
 "feedback.screenshot_label" = "ภาพหน้าจอ";
 "feedback.screenshot_add" = "เพิ่มภาพหน้าจอ";
 "feedback.screenshot_footer" = "แนบภาพหน้าจอได้สูงสุด 3 ภาพ (ไม่บังคับ)";

--- a/Cathier/tr.lproj/Localizable.strings
+++ b/Cathier/tr.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "GitHub Ayarları";
 "feedback.token_footer" = "Issue göndermek için 'repo' kapsamlı GitHub Kişisel Erişim Tokenı gereklidir. Yalnızca yerel olarak saklanır.";
 "feedback.submit" = "Gönder";
+"feedback.view_all_issues" = "Diğerlerinin önerilerini gör →";
 "feedback.screenshot_label" = "Ekran Görüntüleri";
 "feedback.screenshot_add" = "Ekran görüntüsü ekle";
 "feedback.screenshot_footer" = "İsteğe bağlı olarak en fazla 3 ekran görüntüsü ekleyin.";

--- a/Cathier/vi.lproj/Localizable.strings
+++ b/Cathier/vi.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "feedback.token_section" = "Cài đặt GitHub";
 "feedback.token_footer" = "Cần GitHub Personal Access Token với phạm vi 'repo' để gửi issues. Chỉ lưu cục bộ.";
 "feedback.submit" = "Gửi";
+"feedback.view_all_issues" = "Xem đề xuất của người khác →";
 "feedback.screenshot_label" = "Ảnh chụp màn hình";
 "feedback.screenshot_add" = "Thêm ảnh chụp";
 "feedback.screenshot_footer" = "Đính kèm tối đa 3 ảnh chụp màn hình (tùy chọn).";

--- a/Cathier/zh.lproj/Localizable.strings
+++ b/Cathier/zh.lproj/Localizable.strings
@@ -209,6 +209,7 @@
 "feedback.submit" = "提交";
 "feedback.success" = "提交成功！";
 "feedback.view_issue" = "查看 GitHub Issue →";
+"feedback.view_all_issues" = "看看别人都提了哪些建议 →";
 "feedback.screenshot_label" = "截图";
 "feedback.screenshot_add" = "添加截图";
 "feedback.screenshot_footer" = "可附上最多 3 张截图（可选）。";


### PR DESCRIPTION
Closes #94 — "提交功能建议的输入框下方应该有到 github 的链接"

Auto-generated by @claude. Once Build & Deploy passes, auto-merge-claude will squash this in.