### PR TITLE
feat: illustrate body figure with labeled parts in body scan (closes #96)

### DIFF
--- a/Cathier/Views/CheckIn/BodyScanView.swift
+++ b/Cathier/Views/CheckIn/BodyScanView.swift
@@ -7,6 +7,19 @@ private struct SheetItem: Identifiable {
     let kind: Kind
 }
 
+// MARK: - Figure dot model
+
+private struct FigureDot: Identifiable {
+    let id: String          // body part key (e.g. "头部")
+    let relX: Double        // 0..1 relative to canvas width (280pt)
+    let relY: Double        // 0..1 relative to canvas height (420pt)
+    enum Side { case left, right }
+    let labelSide: Side
+    var part: String { id }
+}
+
+// MARK: - BodyScanView
+
 struct BodyScanView: View {
     @Environment(CheckInViewModel.self) private var viewModel
     @Environment(ConfigService.self) private var config
@@ -14,32 +27,76 @@ struct BodyScanView: View {
 
     @State private var sheetItem: SheetItem?
 
+    // Parts drawn as dots on the figure (front-view anatomical)
+    private static let figureParts: Set<String> = [
+        "头部", "颈部", "喉咙", "肩膀", "胸口", "呼吸",
+        "手臂", "背部", "腹部", "腰部", "手掌", "骨盆", "大腿", "双脚"
+    ]
+
+    // Dot positions relative to the 280×420 canvas
+    private static let figureDots: [FigureDot] = [
+        FigureDot(id: "头部", relX: 0.50, relY: 0.065, labelSide: .right),
+        FigureDot(id: "颈部", relX: 0.50, relY: 0.178, labelSide: .right),
+        FigureDot(id: "喉咙", relX: 0.50, relY: 0.215, labelSide: .left),
+        FigureDot(id: "肩膀", relX: 0.27, relY: 0.250, labelSide: .left),
+        FigureDot(id: "胸口", relX: 0.50, relY: 0.315, labelSide: .right),
+        FigureDot(id: "背部", relX: 0.72, relY: 0.340, labelSide: .right),
+        FigureDot(id: "呼吸", relX: 0.50, relY: 0.368, labelSide: .left),
+        FigureDot(id: "手臂", relX: 0.16, relY: 0.395, labelSide: .right),
+        FigureDot(id: "腹部", relX: 0.50, relY: 0.422, labelSide: .right),
+        FigureDot(id: "腰部", relX: 0.50, relY: 0.462, labelSide: .left),
+        FigureDot(id: "骨盆", relX: 0.50, relY: 0.518, labelSide: .right),
+        FigureDot(id: "手掌", relX: 0.07, relY: 0.562, labelSide: .right),
+        FigureDot(id: "大腿", relX: 0.50, relY: 0.638, labelSide: .right),
+        FigureDot(id: "双脚", relX: 0.50, relY: 0.940, labelSide: .right),
+    ]
+
     var body: some View {
         @Bindable var vm = viewModel
         ScrollView {
-            VStack(alignment: .leading, spacing: 28) {
-                // Body Parts
+            VStack(alignment: .leading, spacing: 24) {
+                // Section header
                 sectionHeader(title: lm.bodyScanWhereTitle, subtitle: lm.bodyScanMultiple)
-                FlowLayout(spacing: 10) {
-                    ForEach(config.bodyParts, id: \.self) { part in
-                        ChipView(
-                            label: lm.display(part),
-                            isSelected: viewModel.selectedBodyParts.contains(part)
-                        ) {
+
+                // Human figure with labeled tappable dots (centered)
+                HStack {
+                    Spacer(minLength: 0)
+                    HumanFigureView(
+                        dots: Self.figureDots,
+                        selectedParts: viewModel.selectedBodyParts,
+                        onToggle: { part in
+                            UIImpactFeedbackGenerator(style: viewModel.selectedBodyParts.contains(part) ? .light : .medium).impactOccurred()
                             toggleBodyPart(part)
-                        }
-                        .simultaneousGesture(
-                            LongPressGesture(minimumDuration: 0.5)
-                                .onEnded { _ in
-                                    if let entry = DictionaryService.bodyPart(for: part) {
-                                        sheetItem = SheetItem(entry: entry, kind: .bodyPart)
+                        },
+                        label: { lm.display($0) }
+                    )
+                    Spacer(minLength: 0)
+                }
+
+                // Supplementary chips: face sub-parts, chakras, 整个身体
+                let supplementary = config.bodyParts.filter { !Self.figureParts.contains($0) }
+                if !supplementary.isEmpty {
+                    FlowLayout(spacing: 10) {
+                        ForEach(supplementary, id: \.self) { part in
+                            ChipView(
+                                label: lm.display(part),
+                                isSelected: viewModel.selectedBodyParts.contains(part)
+                            ) {
+                                toggleBodyPart(part)
+                            }
+                            .simultaneousGesture(
+                                LongPressGesture(minimumDuration: 0.5)
+                                    .onEnded { _ in
+                                        if let entry = DictionaryService.bodyPart(for: part) {
+                                            sheetItem = SheetItem(entry: entry, kind: .bodyPart)
+                                        }
                                     }
-                                }
-                        )
+                            )
+                        }
                     }
                 }
 
-                // Per-body-part sensations (shown only when body parts are selected)
+                // Per-body-part sensations (shown when body parts are selected)
                 if !viewModel.selectedBodyParts.isEmpty {
                     Divider()
 
@@ -159,6 +216,144 @@ struct BodyScanView: View {
     }
 }
 
+// MARK: - Human Figure View
+
+private struct HumanFigureView: View {
+    let dots: [FigureDot]
+    let selectedParts: Set<String>
+    let onToggle: (String) -> Void
+    let label: (String) -> String
+
+    private static let canvasWidth: CGFloat = 280
+    private static let canvasHeight: CGFloat = 420
+
+    var body: some View {
+        ZStack {
+            Canvas { ctx, size in
+                drawFigure(&ctx, size)
+            }
+
+            ForEach(dots) { dot in
+                BodyDotLabel(
+                    text: label(dot.part),
+                    isSelected: selectedParts.contains(dot.part),
+                    side: dot.labelSide
+                ) {
+                    onToggle(dot.part)
+                }
+                .position(
+                    x: Self.canvasWidth * dot.relX,
+                    y: Self.canvasHeight * dot.relY
+                )
+            }
+        }
+        .frame(width: Self.canvasWidth, height: Self.canvasHeight)
+    }
+
+    private func drawFigure(_ context: inout GraphicsContext, _ size: CGSize) {
+        let w = size.width
+        let h = size.height
+        let headCy = h * 0.065
+        let headR = w * 0.085
+
+        var figure = Path()
+
+        // Head circle
+        figure.addEllipse(in: CGRect(
+            x: w * 0.50 - headR, y: headCy - headR,
+            width: headR * 2, height: headR * 2
+        ))
+
+        // Neck
+        figure.move(to: CGPoint(x: w * 0.50, y: headCy + headR))
+        figure.addLine(to: CGPoint(x: w * 0.50, y: h * 0.235))
+
+        // Left shoulder
+        figure.move(to: CGPoint(x: w * 0.50, y: h * 0.235))
+        figure.addLine(to: CGPoint(x: w * 0.22, y: h * 0.255))
+
+        // Right shoulder
+        figure.move(to: CGPoint(x: w * 0.50, y: h * 0.235))
+        figure.addLine(to: CGPoint(x: w * 0.78, y: h * 0.255))
+
+        // Left arm: shoulder → elbow → wrist
+        figure.move(to: CGPoint(x: w * 0.22, y: h * 0.255))
+        figure.addLine(to: CGPoint(x: w * 0.11, y: h * 0.420))
+        figure.addLine(to: CGPoint(x: w * 0.07, y: h * 0.565))
+
+        // Right arm (symmetric)
+        figure.move(to: CGPoint(x: w * 0.78, y: h * 0.255))
+        figure.addLine(to: CGPoint(x: w * 0.89, y: h * 0.420))
+        figure.addLine(to: CGPoint(x: w * 0.93, y: h * 0.565))
+
+        // Torso: left side, right side, bottom
+        figure.move(to: CGPoint(x: w * 0.22, y: h * 0.255))
+        figure.addLine(to: CGPoint(x: w * 0.25, y: h * 0.520))
+        figure.move(to: CGPoint(x: w * 0.78, y: h * 0.255))
+        figure.addLine(to: CGPoint(x: w * 0.75, y: h * 0.520))
+        figure.move(to: CGPoint(x: w * 0.25, y: h * 0.520))
+        figure.addLine(to: CGPoint(x: w * 0.75, y: h * 0.520))
+
+        // Left leg
+        figure.move(to: CGPoint(x: w * 0.38, y: h * 0.520))
+        figure.addLine(to: CGPoint(x: w * 0.35, y: h * 0.730))
+        figure.addLine(to: CGPoint(x: w * 0.33, y: h * 0.935))
+
+        // Right leg
+        figure.move(to: CGPoint(x: w * 0.62, y: h * 0.520))
+        figure.addLine(to: CGPoint(x: w * 0.65, y: h * 0.730))
+        figure.addLine(to: CGPoint(x: w * 0.67, y: h * 0.935))
+
+        // Feet
+        figure.move(to: CGPoint(x: w * 0.33, y: h * 0.935))
+        figure.addLine(to: CGPoint(x: w * 0.20, y: h * 0.950))
+        figure.move(to: CGPoint(x: w * 0.67, y: h * 0.935))
+        figure.addLine(to: CGPoint(x: w * 0.80, y: h * 0.950))
+
+        context.stroke(figure, with: .color(Color(uiColor: .systemGray3)), lineWidth: 2.0)
+    }
+}
+
+// MARK: - Body Dot Label
+
+private struct BodyDotLabel: View {
+    let text: String
+    let isSelected: Bool
+    let side: FigureDot.Side
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 5) {
+            if side == .right {
+                dotCircle
+                labelText
+            } else {
+                labelText
+                dotCircle
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture(perform: action)
+        .animation(.easeOut(duration: 0.15), value: isSelected)
+    }
+
+    private var dotCircle: some View {
+        Circle()
+            .fill(isSelected ? Color.cathierAccent : Color(uiColor: .systemGray3))
+            .frame(width: isSelected ? 12 : 9, height: isSelected ? 12 : 9)
+            .shadow(
+                color: isSelected ? Color.cathierAccent.opacity(0.45) : .clear,
+                radius: 5
+            )
+    }
+
+    private var labelText: some View {
+        Text(text)
+            .font(.system(size: 10, weight: isSelected ? .semibold : .regular))
+            .foregroundColor(isSelected ? Color.cathierAccent : Color(uiColor: .secondaryLabel))
+    }
+}
+
 // MARK: - Intensity Slider
 
 private struct IntensitySlider: View {
@@ -234,13 +429,11 @@ struct FlowLayout: Layout {
         }
     }
 
-    /// Returns the subview's natural size, but clamped to maxWidth.
     private func clampedSize(of subview: LayoutSubview, maxWidth: CGFloat) -> CGSize {
         let natural = subview.sizeThatFits(.unspecified)
         if natural.width <= maxWidth {
             return natural
         }
-        // Re-measure with constrained width so text wraps
         return subview.sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
     }
 


### PR DESCRIPTION
Closes #96 — "身体扫描应该画个人并把这些部位标注出来"

Auto-generated by @claude. Once Build & Deploy passes, auto-merge-claude will squash this in.